### PR TITLE
Add  GraphiteReporter.Builder.timedThresholdMicros()

### DIFF
--- a/metrics-graphite/src/main/java/io/avaje/metrics/graphite/DGraphiteBuilder.java
+++ b/metrics-graphite/src/main/java/io/avaje/metrics/graphite/DGraphiteBuilder.java
@@ -17,6 +17,7 @@ final class DGraphiteBuilder implements GraphiteReporter.Builder {
   private String prefix;
   private String hostname;
   private int port;
+  private long timedThresholdMicros;
   private SocketFactory socketFactory = SSLSocketFactory.getDefault();
 
   private final List<GraphiteSender.Reporter> reporters = new ArrayList<>();
@@ -57,7 +58,14 @@ final class DGraphiteBuilder implements GraphiteReporter.Builder {
     this.excludeDefaultRegistry = true;
     return this;
   }
-    @Override
+
+  @Override
+  public DGraphiteBuilder timedThresholdMicros(int timedThresholdMicros) {
+    this.timedThresholdMicros = timedThresholdMicros;
+    return this;
+  }
+
+  @Override
   public DGraphiteBuilder database(Database database) {
     reporters.add(DatabaseReporter.reporter(database));
     return this;
@@ -84,11 +92,11 @@ final class DGraphiteBuilder implements GraphiteReporter.Builder {
       throw new IllegalStateException("Unknown host " + address.getHostName());
     }
 
-    return new DGraphiteSender(address, socketFactory, batchSize, prefix);
+    return new DGraphiteSender(address, socketFactory, batchSize, prefix, timedThresholdMicros);
   }
 
   public GraphiteReporter build() {
-    if (!excludeDefaultRegistry){
+    if (!excludeDefaultRegistry) {
       reporters.add(new DRegistryReporter(Metrics.registry()));
     }
     return new DGraphiteReporter(buildSender(), reporters);

--- a/metrics-graphite/src/main/java/io/avaje/metrics/graphite/GraphiteReporter.java
+++ b/metrics-graphite/src/main/java/io/avaje/metrics/graphite/GraphiteReporter.java
@@ -95,6 +95,21 @@ public interface GraphiteReporter {
     Builder excludeDefaultRegistry();
 
     /**
+     * Set a threshold where timed metrics with total time less than the
+     * threshold are not reported.
+     * <p>
+     * This can use used to when metrics are applied fairly globally (for
+     * example on all Spring components or all avaje-inject components)
+     * and hence can include methods that are not that interesting for
+     * collecting timing on.
+     * <p>
+     * Setting this to 1000 (which is 1 millisecond) when reporting every 1 minute
+     * means that methods with total execution time less than 1ms in a one-minute period
+     * will not be reported.
+     */
+    Builder timedThresholdMicros(int timedThresholdMicros);
+
+    /**
      * Include Ebean Database metrics in the reporting.
      * <p>
      * This can be used multiple times for each database that we want to


### PR DESCRIPTION
This can be used typically when using enhancement to add metrics to all spring components or all avaje-inject components to filter out timing metrics and not report them when method total execution time does not exceed the
threshold specified.