### PR TITLE
Allow ScheduledTask.cancel() without actually being started

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,14 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Java
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java_version }}
         distribution: 'zulu'
     - name: Maven cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       env:
         cache-name: maven-cache
       with:

--- a/metrics/src/main/java/io/avaje/metrics/DScheduledTask.java
+++ b/metrics/src/main/java/io/avaje/metrics/DScheduledTask.java
@@ -65,6 +65,9 @@ final class DScheduledTask implements ScheduledTask {
 
   @Override
   public boolean cancel(boolean mayInterruptIfRunning) {
+    if (backgroundTask == null) {
+      return false;
+    }
     return this.backgroundTask.cancel(mayInterruptIfRunning);
   }
 

--- a/metrics/src/main/java/io/avaje/metrics/ScheduledTask.java
+++ b/metrics/src/main/java/io/avaje/metrics/ScheduledTask.java
@@ -25,6 +25,7 @@ public interface ScheduledTask {
 
   /**
    * Cancel the scheduled task.
+   * @return true if the task was cancelled otherwise false
    */
   boolean cancel(boolean mayInterruptIfRunning);
 

--- a/metrics/src/test/java/io/avaje/metrics/ScheduledTaskTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/ScheduledTaskTest.java
@@ -10,6 +10,26 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ScheduledTaskTest {
 
   @Test
+  void stopWithoutStart() {
+    ScheduledTask task = ScheduledTask.builder()
+      .schedule(1, 1, TimeUnit.MILLISECONDS)
+      .task(ScheduledTaskTest::hello)
+      .build();
+
+    task.cancel(true);
+  }
+
+  @Test
+  void waitWithoutStart() {
+    ScheduledTask task = ScheduledTask.builder()
+      .schedule(1, 1, TimeUnit.MILLISECONDS)
+      .task(ScheduledTaskTest::hello)
+      .build();
+
+    task.waitIfRunning(10, TimeUnit.SECONDS);
+  }
+
+  @Test
   void runIt() throws InterruptedException {
 
     ScheduledTask task = ScheduledTask.builder()


### PR DESCRIPTION
Throws a NPE without this change.