### PR TITLE
Fix NPE when using CGroup metrics with no cpu limit

### DIFF
--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -21,6 +21,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.jspecify</groupId>
+      <artifactId>jspecify</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
       <version>1.5</version>

--- a/metrics/src/main/java/io/avaje/metrics/Timer.java
+++ b/metrics/src/main/java/io/avaje/metrics/Timer.java
@@ -1,5 +1,7 @@
 package io.avaje.metrics;
 
+import org.jspecify.annotations.Nullable;
+
 import java.util.function.Supplier;
 
 /**
@@ -122,7 +124,7 @@ public interface Timer extends Metric {
   /**
    * Return the bucket range or empty string if not a bucket.
    */
-  String bucketRange();
+  @Nullable String bucketRange();
 
   /**
    * Statistics collected by Timer.
@@ -132,7 +134,7 @@ public interface Timer extends Metric {
     /**
      * Return the bucket range for these statistics.
      */
-    default String bucketRange() {
+    default @Nullable String bucketRange() {
       return null;
     }
   }

--- a/metrics/src/main/java/io/avaje/metrics/core/BaseReportName.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/BaseReportName.java
@@ -1,11 +1,12 @@
 package io.avaje.metrics.core;
 
 import io.avaje.metrics.Metric;
+import org.jspecify.annotations.Nullable;
 
 abstract class BaseReportName {
 
   final String name;
-  String reportName;
+  @Nullable String reportName;
 
   BaseReportName(String name) {
     this.name = name;

--- a/metrics/src/main/java/io/avaje/metrics/core/DBucketTimer.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DBucketTimer.java
@@ -1,6 +1,7 @@
 package io.avaje.metrics.core;
 
 import io.avaje.metrics.Timer;
+import org.jspecify.annotations.Nullable;
 
 import java.util.function.Supplier;
 
@@ -27,7 +28,7 @@ final class DBucketTimer implements Timer {
   }
 
   @Override
-  public String bucketRange() {
+  public @Nullable String bucketRange() {
     return null;
   }
 

--- a/metrics/src/main/java/io/avaje/metrics/core/DCounter.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DCounter.java
@@ -20,7 +20,6 @@ final class DCounter extends BaseReportName implements Counter {
    * <p>
    * The rateUnit should be chosen to 'scale' the statistics in a reasonable
    * manor - typically events per hour, minute or second.
-   * </p>
    */
   DCounter(String name) {
     super(name);

--- a/metrics/src/main/java/io/avaje/metrics/core/DTimer.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DTimer.java
@@ -1,6 +1,7 @@
 package io.avaje.metrics.core;
 
 import io.avaje.metrics.Timer;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -14,7 +15,7 @@ import java.util.function.Supplier;
 final class DTimer implements Timer {
 
   private final String name;
-  private final String bucketRange;
+  private final @Nullable String bucketRange;
   private final ValueCounter successCounter;
   private final ValueCounter errorCounter;
 
@@ -38,7 +39,7 @@ final class DTimer implements Timer {
   }
 
   @Override
-  public String bucketRange() {
+  public @Nullable String bucketRange() {
     return bucketRange;
   }
 

--- a/metrics/src/main/java/io/avaje/metrics/core/DTimerEvent.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DTimerEvent.java
@@ -25,7 +25,7 @@ final class DTimerEvent implements Timer.Event {
 
   @Override
   public String toString() {
-    return metric.toString() + " durationMillis:" + duration();
+    return metric + " durationMillis:" + duration();
   }
 
   /**

--- a/metrics/src/main/java/io/avaje/metrics/core/DefaultMetricProvider.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DefaultMetricProvider.java
@@ -4,8 +4,6 @@ import io.avaje.metrics.*;
 import io.avaje.metrics.spi.SpiMetricBuilder;
 import io.avaje.metrics.spi.SpiMetricProvider;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;

--- a/metrics/src/main/java/io/avaje/metrics/core/FileLines.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/FileLines.java
@@ -1,5 +1,8 @@
 package io.avaje.metrics.core;
 
+import io.avaje.applog.AppLog;
+import org.jspecify.annotations.Nullable;
+
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
@@ -12,7 +15,7 @@ import java.util.function.Predicate;
 
 final class FileLines {
 
-  private static final System.Logger log = System.getLogger("io.avaje.metrics");
+  private static final System.Logger log = AppLog.getLogger("io.avaje.metrics");
 
   private final File file;
 
@@ -65,7 +68,7 @@ final class FileLines {
     }
   }
 
-  private String readLine() {
+  private @Nullable String readLine() {
     try {
       try (LineNumberReader lineReader = new LineNumberReader(new FileReader(file))) {
         return lineReader.readLine();

--- a/metrics/src/main/java/io/avaje/metrics/core/JsonWriter.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/JsonWriter.java
@@ -1,6 +1,7 @@
 package io.avaje.metrics.core;
 
 import io.avaje.metrics.*;
+
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.text.DecimalFormat;
@@ -114,7 +115,7 @@ final class JsonWriter implements Metric.Visitor {
 
   private void writeSummary(Meter.Stats valueStats) throws IOException {
     // valueStats == null when BucketTimedMetric and the bucket is empty
-    long count = (valueStats == null) ? 0 : valueStats.count();
+    long count = valueStats.count();
     writeKeyNumber("count", count);
     if (count != 0) {
       buffer.append(",");

--- a/metrics/src/main/java/io/avaje/metrics/core/JvmProcessMemory.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/JvmProcessMemory.java
@@ -1,6 +1,7 @@
 package io.avaje.metrics.core;
 
 import io.avaje.metrics.MetricRegistry;
+import org.jspecify.annotations.Nullable;
 
 import java.lang.management.ManagementFactory;
 
@@ -11,7 +12,7 @@ final class JvmProcessMemory {
 
   private static final long TO_MEGABYTES = 1024L;
 
-  private final String pid;
+  private final @Nullable String pid;
 
   /**
    * Return the list of OS process memory metrics.
@@ -30,7 +31,7 @@ final class JvmProcessMemory {
   /**
    * Return the PID (when running on linux).
    */
-  private String linuxPid() {
+  private @Nullable String linuxPid() {
     String os = System.getProperty("os.name").toLowerCase();
     if (os.contains("linux")) {
       String[] parts = ManagementFactory.getRuntimeMXBean().getName().split("@");

--- a/metrics/src/main/java/io/avaje/metrics/core/ValueCounter.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/ValueCounter.java
@@ -3,6 +3,7 @@ package io.avaje.metrics.core;
 import io.avaje.metrics.Metric;
 import io.avaje.metrics.Timer;
 import io.avaje.metrics.stats.TimerStats;
+import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.atomic.LongAccumulator;
 import java.util.concurrent.atomic.LongAdder;
@@ -15,7 +16,7 @@ import java.util.concurrent.atomic.LongAdder;
  */
 final class ValueCounter extends BaseReportName {
 
-  private final String bucketRange;
+  private final @Nullable String bucketRange;
   private final LongAdder count = new LongAdder();
   private final LongAdder total = new LongAdder();
   private final LongAccumulator max = new LongAccumulator(Math::max, Long.MIN_VALUE);
@@ -48,7 +49,7 @@ final class ValueCounter extends BaseReportName {
     max.accumulate(value);
   }
 
-  Timer.Stats collect(Metric.Visitor collector) {
+  Timer.@Nullable Stats collect(Metric.Visitor collector) {
     final long count = this.count.sumThenReset();
     if (count == 0) {
       return null;

--- a/metrics/src/main/java/io/avaje/metrics/core/package-info.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package io.avaje.metrics.core;
+
+import org.jspecify.annotations.NullMarked;

--- a/metrics/src/main/java/io/avaje/metrics/package-info.java
+++ b/metrics/src/main/java/io/avaje/metrics/package-info.java
@@ -11,4 +11,7 @@
  *
  * @see io.avaje.metrics.Metrics
  */
+@NullMarked
 package io.avaje.metrics;
+
+import org.jspecify.annotations.NullMarked;

--- a/metrics/src/main/java/io/avaje/metrics/stats/TimerStats.java
+++ b/metrics/src/main/java/io/avaje/metrics/stats/TimerStats.java
@@ -2,6 +2,7 @@ package io.avaje.metrics.stats;
 
 import io.avaje.metrics.Metric;
 import io.avaje.metrics.Timer;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Snapshot of the current statistics for a Meter or Timer.
@@ -9,7 +10,7 @@ import io.avaje.metrics.Timer;
 public final class TimerStats implements Timer.Stats {
 
   final String name;
-  final String bucketRange;
+  final @Nullable String bucketRange;
   final long count;
   final long total;
   final long max;
@@ -24,14 +25,14 @@ public final class TimerStats implements Timer.Stats {
   /**
    * Create with all parameters including bucketRange.
    */
-  public TimerStats(String name, String bucketRange, long count, long total, long max) {
+  public TimerStats(String name, @Nullable  String bucketRange, long count, long total, long max) {
     this.name = name;
     this.bucketRange = bucketRange;
     this.count = count;
     this.total = total;
     // collection is racy so sanitize the max value if it has not been set
     // this most likely would happen when count = 1 so max = mean
-    this.max = max != Long.MIN_VALUE ? max : (count < 1 ? 0 : Math.round(total / count));
+    this.max = max != Long.MIN_VALUE ? max : (count < 1 ? 0 : Math.round((float) total / count));
   }
 
   @Override
@@ -45,7 +46,7 @@ public final class TimerStats implements Timer.Stats {
   }
 
   @Override
-  public String bucketRange() {
+  public @Nullable String bucketRange() {
     return bucketRange;
   }
 

--- a/metrics/src/main/java/io/avaje/metrics/stats/package-info.java
+++ b/metrics/src/main/java/io/avaje/metrics/stats/package-info.java
@@ -5,4 +5,7 @@
  *
  * @see io.avaje.metrics.Metrics#addSupplier(io.avaje.metrics.MetricSupplier)
  */
+@NullMarked
 package io.avaje.metrics.stats;
+
+import org.jspecify.annotations.NullMarked;

--- a/metrics/src/main/java/module-info.java
+++ b/metrics/src/main/java/module-info.java
@@ -1,5 +1,4 @@
 import io.avaje.metrics.core.DefaultMetricProvider;
-import io.avaje.metrics.spi.SpiMetricProvider;
 
 module io.avaje.metrics {
 
@@ -9,6 +8,7 @@ module io.avaje.metrics {
   exports io.avaje.metrics.annotation;
 
   requires transitive io.avaje.applog;
+  requires transitive org.jspecify;
   requires static java.management;
 
   uses io.avaje.metrics.spi.SpiMetricBuilder;

--- a/metrics/src/main/java/module-info.java
+++ b/metrics/src/main/java/module-info.java
@@ -12,6 +12,6 @@ module io.avaje.metrics {
   requires static java.management;
 
   uses io.avaje.metrics.spi.SpiMetricBuilder;
-  uses SpiMetricProvider;
-  provides SpiMetricProvider with DefaultMetricProvider;
+  uses io.avaje.metrics.spi.SpiMetricProvider;
+  provides io.avaje.metrics.spi.SpiMetricProvider with DefaultMetricProvider;
 }

--- a/metrics/src/test/java/io/avaje/metrics/core/JvmCGroupCpuMetricGroupTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/JvmCGroupCpuMetricGroupTest.java
@@ -4,6 +4,8 @@ package io.avaje.metrics.core;
 import io.avaje.metrics.GaugeLong;
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -58,9 +60,13 @@ class JvmCGroupCpuMetricGroupTest {
     assertTrue(period.exists());
 
     JvmCGroupCpu me = new JvmCGroupCpu();
-    final GaugeLong metric = me.createCGroupCpuLimit(cpuQuota, period);
-    final long limit = metric.value();
-    assertThat(limit).isEqualTo(600L);
+    Optional<GaugeLong> cGroupCpuLimit = me.createCGroupCpuLimit(cpuQuota, period);
+    assertThat(cGroupCpuLimit)
+      .isPresent()
+      .hasValueSatisfying(metric -> {
+        final long limit = metric.value();
+        assertThat(limit).isEqualTo(600L);
+      });
   }
 
   @Test


### PR DESCRIPTION
```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "io.avaje.metrics.Metric.name()" because "metric" is null
	at io.avaje.metrics.core.DefaultMetricProvider.register(DefaultMetricProvider.java:235)
	at io.avaje.metrics.core.JvmCGroupCpu.create(JvmCGroupCpu.java:33)
	at io.avaje.metrics.core.JvmCGroupCpu.createGauges(JvmCGroupCpu.java:14)
	at io.avaje.metrics.core.DefaultMetricProvider.registerCGroupMetrics(DefaultMetricProvider.java:134)
```