### PR TITLE
Rename jvm.cgroup.memory.usageMb to usage for consistency

### DIFF
--- a/metrics/src/main/java/io/avaje/metrics/core/JvmCGroupMemory.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/JvmCGroupMemory.java
@@ -65,7 +65,7 @@ final class JvmCGroupMemory {
   }
 
   GaugeLong usage(MemSource source, boolean reportChangesOnly) {
-    return DGaugeLong.of("jvm.cgroup.memory.usageMb", source::usageMb, reportChangesOnly);
+    return DGaugeLong.of("jvm.cgroup.memory.usage", source::usageMb, reportChangesOnly);
   }
 
   GaugeLong pctUsage(MemSource source, boolean reportChangesOnly) {


### PR DESCRIPTION
All the other memory metrics don't have the Mb units as a suffix to the metric name, so this is more consistent