### PR TITLE
[statsd] Add graalvm native-image support via resource-config.json

### DIFF
--- a/metrics-statsd/src/main/resources/META-INF/native-image/io.avaje.metrics.statsd/statsd-client/resource-config.json
+++ b/metrics-statsd/src/main/resources/META-INF/native-image/io.avaje.metrics.statsd/statsd-client/resource-config.json
@@ -1,0 +1,7 @@
+{
+  "resources": [
+    {
+      "pattern": "dogstatsd/version.properties"
+    }
+  ]
+}


### PR DESCRIPTION
Refer to upstream PR - https://github.com/DataDog/java-dogstatsd-client/pull/270

This is needed to support native-image compilation. The dogstatsd/version.properties resource is read when creating the NonBlockingStatsDClient at:

NonBlockingStatsDClient.(NonBlockingStatsDClient.java:309)

Adding the META-INF/native-image/com.datadoghq/dogstatsd-client/resource-config.json is the fix to
avoid the following stack trace.

```
Exception in thread "main" com.timgroup.statsd.StatsDClientException: Failed to start StatsD client
at com.timgroup.statsd.NonBlockingStatsDClient.(NonBlockingStatsDClient.java:348)
at com.timgroup.statsd.NonBlockingStatsDClient.(NonBlockingStatsDClient.java:374)
at com.timgroup.statsd.NonBlockingStatsDClientBuilder.build(NonBlockingStatsDClientBuilder.java:211)
at io.avaje.metrics.statsd.StatsdBuilder.build(StatsdBuilder.java:99)
... truncated
Caused by: java.lang.NullPointerException: inStream parameter is null
at java.base@24.0.1/java.util.Objects.requireNonNull(Objects.java:246)
at java.base@24.0.1/java.util.Properties.load(Properties.java:409)
at com.timgroup.statsd.NonBlockingStatsDClient.(NonBlockingStatsDClient.java:309)
... 11 more
```