### PR TITLE
[statsd] Exclude by default the com.github.jnr:jnr-unixsocket dependency

### DIFF
--- a/metrics-statsd/pom.xml
+++ b/metrics-statsd/pom.xml
@@ -23,6 +23,12 @@
       <groupId>com.datadoghq</groupId>
       <artifactId>java-dogstatsd-client</artifactId>
       <version>4.4.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.github.jnr</groupId>
+          <artifactId>jnr-unixsocket</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Explicitly include it when needed (but at this stage I don't expect it to be commonly used with avaje metrics so excluding it and its transitive dependencies by default).