### PR TITLE
Add OTEL open telemetry reporter module

### DIFF
--- a/metrics-otel/README.md
+++ b/metrics-otel/README.md
@@ -1,0 +1,228 @@
+# avaje-metrics-otel
+
+Exports [avaje-metrics](https://avaje-metrics.github.io) to [OpenTelemetry](https://opentelemetry.io/)
+using the OTEL SDK Metrics API.
+
+The module collects avaje metrics on a configurable schedule and pushes them to the provided
+`OpenTelemetry` or `MeterProvider` instance. The OTEL SDK and its configured exporters
+(OTLP, Prometheus, logging, etc.) handle shipping the data to your backend.
+
+## Maven dependency
+
+```xml
+<dependency>
+  <groupId>io.avaje</groupId>
+  <artifactId>avaje-metrics-otel</artifactId>
+  <version>9.8</version>
+</dependency>
+```
+
+An `opentelemetry-api` dependency is required at runtime. This module declares it as `provided`,
+so you must add the OTEL SDK and at least one exporter to your own project:
+
+```xml
+<!-- OTEL SDK + exporter of your choice -->
+<dependency>
+  <groupId>io.opentelemetry</groupId>
+  <artifactId>opentelemetry-sdk</artifactId>
+  <version>1.44.0</version>
+</dependency>
+<dependency>
+  <groupId>io.opentelemetry</groupId>
+  <artifactId>opentelemetry-exporter-otlp</artifactId>
+  <version>1.44.0</version>
+</dependency>
+```
+
+## Basic usage
+
+```java
+// Configure and build the reporter
+OtelReporter reporter = OtelReporter.builder()
+    .openTelemetry(openTelemetry)        // provide your configured OpenTelemetry instance
+    .schedule(60, TimeUnit.SECONDS)      // report every 60 seconds (default)
+    .build();
+
+reporter.start();
+
+// On shutdown:
+reporter.close();
+```
+
+## Builder options
+
+```java
+OtelReporter reporter = OtelReporter.builder()
+
+    // Provide the OpenTelemetry instance (preferred)
+    .openTelemetry(openTelemetry)
+
+    // Or provide a MeterProvider directly
+    .meterProvider(meterProvider)
+
+    // Use a non-default MetricRegistry (defaults to Metrics.registry())
+    .registry(myRegistry)
+
+    // Reporting interval (default: 60 seconds)
+    .schedule(60, TimeUnit.SECONDS)
+
+    // Skip timer metrics whose total duration is below this threshold.
+    // Useful when @Timed is applied broadly and many methods are trivial.
+    // 1_000 = skip timers with less than 1ms total execution per interval.
+    .timedThresholdMicros(1_000)
+
+    // OpenTelemetry instrumentation scope name (default: "io.avaje.metrics")
+    .scopeName("io.avaje.metrics")
+
+    .build();
+```
+
+## Metric mapping
+
+avaje metrics are mapped to OTEL instruments as follows:
+
+| avaje type | OTEL instruments | Notes |
+|---|---|---|
+| `Counter` | `LongCounter` | delta count per interval; OTEL SDK accumulates to cumulative |
+| `Timer` | `LongCounter` (`name.count`), `LongCounter` (`name.total`), `LongGauge` (`name.max`) | values in microseconds (`us`) |
+| `Meter` | `LongCounter` (`name.count`), `LongCounter` (`name.total`), `LongGauge` (`name.max`) | values in user-defined units |
+| `GaugeLong` | `LongGauge` | current value, set each interval |
+| `GaugeDouble` | `DoubleGauge` | current value, set each interval |
+
+### Timer success and error
+
+avaje timers track success and error events separately. They are reported as two distinct metric
+name series: `name` (success) and `name.error` (errors). Each produces its own set of `count`,
+`total`, and `max` instruments.
+
+### Tags
+
+avaje tags use a `key:value` colon-separated format. These are converted to OTEL `Attributes`:
+
+```java
+// avaje
+Counter counter = registry.counter("app.login", Tags.of("env:prod", "region:us-east-1"));
+
+// becomes OTEL attributes: {env="prod", region="us-east-1"}
+```
+
+## Reporting manually
+
+If you prefer to manage the reporting schedule yourself rather than using the built-in scheduler:
+
+```java
+OtelReporter reporter = OtelReporter.builder()
+    .openTelemetry(openTelemetry)
+    .build();
+
+// Call report() on your own schedule
+reporter.report();
+```
+
+## Using with the OTEL Java agent
+
+When running with the OpenTelemetry Java agent, the agent installs a global `OpenTelemetry`
+instance. You can use it directly:
+
+```java
+import io.opentelemetry.api.GlobalOpenTelemetry;
+
+OtelReporter reporter = OtelReporter.builder()
+    .openTelemetry(GlobalOpenTelemetry.get())
+    .schedule(60, TimeUnit.SECONDS)
+    .build();
+
+reporter.start();
+```
+
+## Example: avaje-inject
+
+When using [avaje-inject](https://avaje.io/inject/), configure the reporter via a `@Factory` class.
+`OtelReporter` implements `AutoCloseable`, so avaje-inject will call `close()` automatically
+on container shutdown.
+
+```java
+import io.avaje.inject.Bean;
+import io.avaje.inject.Factory;
+import io.avaje.metrics.otel.OtelReporter;
+import io.opentelemetry.api.OpenTelemetry;
+import java.util.concurrent.TimeUnit;
+
+@Factory
+class MetricsConfig {
+
+  @Bean
+  OpenTelemetry openTelemetry() {
+    // setup via OTEL Java agent, autoconfiguration or manual SDK configuration
+    // return GlobalOpenTelemetry.get();
+    return AutoConfiguredOpenTelemetrySdk.initialize().getOpenTelemetrySdk();
+  }
+
+  @Bean
+  OtelReporter otelReporter(OpenTelemetry openTelemetry) {
+    OtelReporter reporter = OtelReporter.builder()
+        .openTelemetry(openTelemetry)
+        .schedule(60, TimeUnit.SECONDS)
+        .timedThresholdMicros(1_000)
+        .build();
+    reporter.start();
+    return reporter;
+    // close() is called automatically by avaje-inject on shutdown (AutoCloseable)
+  }
+}
+```
+
+
+## Example: Configure OTEL SDK with OTLP gRPC exporter
+
+```java
+// Configure OTEL SDK with OTLP gRPC exporter
+SdkMeterProvider meterProvider = SdkMeterProvider.builder()
+    .setResource(Resource.getDefault().toBuilder()
+        .put(ServiceAttributes.SERVICE_NAME, "my-service")
+        .build())
+    .registerMetricReader(
+        PeriodicMetricReader.builder(
+            OtlpGrpcMetricExporter.builder()
+                .setEndpoint("http://otel-collector:4317")
+                .build())
+        .setInterval(Duration.ofSeconds(60))
+        .build())
+    .build();
+
+OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
+    .setMeterProvider(meterProvider)
+    .build();
+
+OtelReporter reporter = OtelReporter.builder()
+    .openTelemetry(openTelemetry)
+    .timedThresholdMicros(1_000)
+    .build();
+
+reporter.start();
+```
+
+## Example: Prometheus scrape endpoint
+
+```java
+// Configure OTEL SDK with Prometheus exporter (pull-based)
+PrometheusHttpServer prometheusServer = PrometheusHttpServer.builder()
+    .setPort(9464)
+    .build();
+
+SdkMeterProvider meterProvider = SdkMeterProvider.builder()
+    .registerMetricReader(prometheusServer)
+    .build();
+
+OpenTelemetry openTelemetry = OpenTelemetrySdk.builder()
+    .setMeterProvider(meterProvider)
+    .build();
+
+OtelReporter reporter = OtelReporter.builder()
+    .openTelemetry(openTelemetry)
+    .build();
+
+reporter.start();
+```
+
+Metrics are then available at `http://localhost:9464/metrics` for Prometheus to scrape.

--- a/metrics-otel/pom.xml
+++ b/metrics-otel/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>avaje-metrics-parent</artifactId>
+    <groupId>io.avaje</groupId>
+    <version>9.7-RC2</version>
+  </parent>
+
+  <artifactId>avaje-metrics-otel</artifactId>
+  <name>avaje-metrics-otel</name>
+  <version>9.7-RC2</version>
+
+  <properties>
+    <surefire.useModulePath>false</surefire.useModulePath>
+  </properties>
+
+  <dependencies>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-applog</artifactId>
+      <version>1.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>avaje-metrics</artifactId>
+      <version>9.7-RC2</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-api</artifactId>
+      <version>1.44.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.avaje</groupId>
+      <artifactId>junit</artifactId>
+      <version>1.5</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk</artifactId>
+      <version>1.44.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentelemetry</groupId>
+      <artifactId>opentelemetry-sdk-testing</artifactId>
+      <version>1.44.0</version>
+      <scope>test</scope>
+    </dependency>
+
+  </dependencies>
+
+</project>

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/DOtelBuilder.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/DOtelBuilder.java
@@ -1,0 +1,82 @@
+package io.avaje.metrics.otel;
+
+import io.avaje.metrics.MetricRegistry;
+import io.avaje.metrics.Metrics;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.Meter;
+import io.opentelemetry.api.metrics.MeterProvider;
+
+import java.util.concurrent.TimeUnit;
+
+final class DOtelBuilder implements OtelReporter.Builder {
+
+  private static final String DEFAULT_SCOPE = "io.avaje.metrics";
+
+  private OpenTelemetry openTelemetry;
+  private MeterProvider meterProvider;
+  private MetricRegistry registry;
+  private int schedule = 60;
+  private TimeUnit scheduleTimeUnit = TimeUnit.SECONDS;
+  private long timedThresholdMicros = 0;
+  private String scopeName = DEFAULT_SCOPE;
+
+  @Override
+  public OtelReporter.Builder openTelemetry(OpenTelemetry openTelemetry) {
+    this.openTelemetry = openTelemetry;
+    return this;
+  }
+
+  @Override
+  public OtelReporter.Builder meterProvider(MeterProvider meterProvider) {
+    this.meterProvider = meterProvider;
+    return this;
+  }
+
+  @Override
+  public OtelReporter.Builder registry(MetricRegistry registry) {
+    this.registry = registry;
+    return this;
+  }
+
+  @Override
+  public OtelReporter.Builder schedule(int schedule, TimeUnit timeUnit) {
+    this.schedule = schedule;
+    this.scheduleTimeUnit = timeUnit;
+    return this;
+  }
+
+  @Override
+  public OtelReporter.Builder timedThresholdMicros(long threshold) {
+    this.timedThresholdMicros = threshold;
+    return this;
+  }
+
+  @Override
+  public OtelReporter.Builder scopeName(String scopeName) {
+    this.scopeName = scopeName;
+    return this;
+  }
+
+  @Override
+  public OtelReporter build() {
+    MetricRegistry effectiveRegistry = registry != null ? registry : Metrics.registry();
+    Meter otelMeter = resolveMeter();
+    OtelVisitor visitor = new OtelVisitor(otelMeter, timedThresholdMicros);
+    return new DOtelReporter(effectiveRegistry, visitor, schedule, scheduleTimeUnit);
+  }
+
+  private Meter resolveMeter() {
+    MeterProvider provider = resolveProvider();
+    return provider.meterBuilder(scopeName).build();
+  }
+
+  private MeterProvider resolveProvider() {
+    if (meterProvider != null) {
+      return meterProvider;
+    }
+    if (openTelemetry != null) {
+      return openTelemetry.getMeterProvider();
+    }
+    return OpenTelemetry.noop().getMeterProvider();
+  }
+}

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/DOtelReporter.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/DOtelReporter.java
@@ -1,0 +1,64 @@
+package io.avaje.metrics.otel;
+
+import io.avaje.applog.AppLog;
+import io.avaje.metrics.Metric;
+import io.avaje.metrics.MetricRegistry;
+import io.avaje.metrics.ScheduledTask;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.lang.System.Logger.Level.DEBUG;
+import static java.lang.System.Logger.Level.WARNING;
+
+final class DOtelReporter implements OtelReporter, Runnable {
+
+  private static final System.Logger log = AppLog.getLogger(OtelReporter.class);
+
+  private final MetricRegistry registry;
+  private final OtelVisitor visitor;
+  private final ScheduledTask scheduledTask;
+  private final AtomicBoolean started = new AtomicBoolean(false);
+
+  DOtelReporter(MetricRegistry registry, OtelVisitor visitor, int schedule, TimeUnit scheduleTimeUnit) {
+    this.registry = registry;
+    this.visitor = visitor;
+    this.scheduledTask = ScheduledTask.builder()
+        .schedule(schedule, schedule, scheduleTimeUnit)
+        .task(this)
+        .build();
+  }
+
+  @Override
+  public void start() {
+    scheduledTask.start();
+    started.set(true);
+  }
+
+  @Override
+  public void close() {
+    if (started.get()) {
+      scheduledTask.cancel(true);
+    }
+  }
+
+  @Override
+  public void report() {
+    run();
+  }
+
+  @Override
+  public void run() {
+    long start = System.currentTimeMillis();
+    try {
+      List<Metric.Statistics> metrics = registry.collectMetrics();
+      for (Metric.Statistics metric : metrics) {
+        metric.visit(visitor);
+      }
+      log.log(DEBUG, "reported {0} metrics to OpenTelemetry in {1}ms", metrics.size(), System.currentTimeMillis() - start);
+    } catch (Exception e) {
+      log.log(WARNING, "Error reporting metrics to OpenTelemetry", e);
+    }
+  }
+}

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/OtelAttributes.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/OtelAttributes.java
@@ -1,0 +1,39 @@
+package io.avaje.metrics.otel;
+
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+
+/**
+ * Converts avaje metrics tags to OpenTelemetry {@link Attributes}.
+ * <p>
+ * Avaje tags use {@code "key:value"} colon-separated format, for example:
+ * {@code "env:prod"}, {@code "region:us-east-1"}.
+ */
+final class OtelAttributes {
+
+  private OtelAttributes() {}
+
+  /**
+   * Convert an avaje tags array to OTEL {@link Attributes}.
+   * <p>
+   * Each tag is split on the first {@code ':'} character. Tags without a colon are skipped.
+   *
+   * @param tags the avaje tags array (may be null or empty)
+   * @return the corresponding OTEL Attributes, or {@link Attributes#empty()} if no valid tags
+   */
+  static Attributes of(String[] tags) {
+    if (tags == null || tags.length == 0) {
+      return Attributes.empty();
+    }
+    AttributesBuilder builder = Attributes.builder();
+    for (String tag : tags) {
+      if (tag != null) {
+        int colon = tag.indexOf(':');
+        if (colon > 0) {
+          builder.put(tag.substring(0, colon), tag.substring(colon + 1));
+        }
+      }
+    }
+    return builder.build();
+  }
+}

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/OtelReporter.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/OtelReporter.java
@@ -1,0 +1,111 @@
+package io.avaje.metrics.otel;
+
+import io.avaje.metrics.MetricRegistry;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.metrics.MeterProvider;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Reports avaje metrics to OpenTelemetry using the OTEL SDK Metrics API.
+ *
+ * <p>The reporter collects avaje metrics periodically and pushes them to the provided
+ * OpenTelemetry {@link MeterProvider}. The OTEL SDK and its configured exporters
+ * (OTLP, Prometheus, etc.) are responsible for shipping the data.
+ *
+ * <pre>{@code
+ *
+ *   OtelReporter reporter = OtelReporter.builder()
+ *       .openTelemetry(openTelemetry)
+ *       .schedule(60, TimeUnit.SECONDS)
+ *       .timedThresholdMicros(1_000)
+ *       .build();
+ *
+ *   reporter.start();
+ *
+ *   // On shutdown:
+ *   reporter.close();
+ *
+ * }</pre>
+ */
+public interface OtelReporter extends AutoCloseable {
+
+  /**
+   * Return a builder for the OtelReporter.
+   */
+  static Builder builder() {
+    return new DOtelBuilder();
+  }
+
+  /**
+   * Collect all metrics and push them to OpenTelemetry once.
+   * <p>
+   * This can be called directly if you prefer to manage the reporting schedule yourself.
+   */
+  void report();
+
+  /**
+   * Start periodic reporting on the configured schedule.
+   */
+  void start();
+
+  /**
+   * Stop periodic reporting.
+   */
+  void close();
+
+  /**
+   * Builder for {@link OtelReporter}.
+   */
+  interface Builder {
+
+    /**
+     * Specify the {@link OpenTelemetry} instance to use.
+     * <p>
+     * This is the preferred way to configure the reporter. If not set, defaults to
+     * {@code GlobalOpenTelemetry.getOrNoop()}.
+     */
+    Builder openTelemetry(OpenTelemetry openTelemetry);
+
+    /**
+     * Specify the {@link MeterProvider} to use directly.
+     * <p>
+     * Use this as an alternative to {@link #openTelemetry(OpenTelemetry)} when you only
+     * have access to the MeterProvider.
+     */
+    Builder meterProvider(MeterProvider meterProvider);
+
+    /**
+     * Specify the {@link MetricRegistry} to report from.
+     * <p>
+     * Defaults to the global registry ({@code Metrics.registry()}).
+     */
+    Builder registry(MetricRegistry registry);
+
+    /**
+     * Specify the reporting schedule. Default is 60 seconds.
+     */
+    Builder schedule(int schedule, TimeUnit timeUnit);
+
+    /**
+     * Set a threshold in microseconds for timed metrics.
+     * <p>
+     * Timer metrics whose total duration is less than this threshold will not be reported.
+     * Default is 0 (report all timers).
+     * <p>
+     * For example, setting to {@code 1_000} (1 millisecond) when reporting every 60 seconds
+     * will suppress methods with less than 1ms total execution time per reporting period.
+     */
+    Builder timedThresholdMicros(long threshold);
+
+    /**
+     * Set the OpenTelemetry instrumentation scope name. Default is {@code "io.avaje.metrics"}.
+     */
+    Builder scopeName(String scopeName);
+
+    /**
+     * Build and return the {@link OtelReporter}.
+     */
+    OtelReporter build();
+  }
+}

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/OtelVisitor.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/OtelVisitor.java
@@ -1,0 +1,127 @@
+package io.avaje.metrics.otel;
+
+import io.avaje.metrics.*;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.metrics.DoubleGauge;
+import io.opentelemetry.api.metrics.LongCounter;
+import io.opentelemetry.api.metrics.LongGauge;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+/**
+ * Implements {@link Metric.Visitor} to map avaje metric statistics to OpenTelemetry instruments.
+ * <p>
+ * Instruments are created lazily on the first visit of each metric name and cached for reuse
+ * on subsequent reporting cycles.
+ * <p>
+ * Mapping:
+ * <ul>
+ *   <li>{@link Counter.Stats} → {@code LongCounter} (add delta count)</li>
+ *   <li>{@link Timer.Stats} → three instruments: {@code .count} (LongCounter),
+ *       {@code .total} (LongCounter, unit {@code us}), {@code .max} (LongGauge, unit {@code us})</li>
+ *   <li>{@link Meter.Stats} → same three instruments as Timer, unit {@code 1}</li>
+ *   <li>{@link GaugeLong.Stats} → {@code LongGauge} (set current value)</li>
+ *   <li>{@link GaugeDouble.Stats} → {@code DoubleGauge} (set current value)</li>
+ * </ul>
+ * Timer success and error stats are naturally handled as separate metrics because avaje
+ * emits them with different names ({@code name} and {@code name.error}).
+ */
+final class OtelVisitor implements Metric.Visitor {
+
+  private final io.opentelemetry.api.metrics.Meter otelMeter;
+  private final long timedThresholdMicros;
+
+  private final ConcurrentHashMap<String, LongCounter> counterCache = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, LongCounter> meterCountCache = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, LongCounter> meterTotalCache = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, LongGauge> meterMaxCache = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, LongGauge> gaugeLongCache = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, DoubleGauge> gaugeDoubleCache = new ConcurrentHashMap<>();
+
+  OtelVisitor(io.opentelemetry.api.metrics.Meter otelMeter, long timedThresholdMicros) {
+    this.otelMeter = otelMeter;
+    this.timedThresholdMicros = timedThresholdMicros;
+  }
+
+  @Override
+  public void visit(Counter.Stats stats) {
+    if (stats.count() == 0) {
+      return;
+    }
+    Attributes attrs = OtelAttributes.of(stats.tags());
+    getOrCreate(counterCache, stats.name(), name ->
+        otelMeter.counterBuilder(name)
+            .setUnit("{event}")
+            .build()
+    ).add(stats.count(), attrs);
+  }
+
+  @Override
+  public void visit(Timer.Stats stats) {
+    if (timedThresholdMicros > 0 && stats.total() < timedThresholdMicros) {
+      return;
+    }
+    if (stats.count() == 0) {
+      return;
+    }
+    recordMeterStats(stats, "us");
+  }
+
+  @Override
+  public void visit(Meter.Stats stats) {
+    if (stats.count() == 0) {
+      return;
+    }
+    recordMeterStats(stats, "1");
+  }
+
+  @Override
+  public void visit(GaugeDouble.Stats stats) {
+    Attributes attrs = OtelAttributes.of(stats.tags());
+    getOrCreate(gaugeDoubleCache, stats.name(), name ->
+        otelMeter.gaugeBuilder(name)
+            .setUnit("1")
+            .build()
+    ).set(stats.value(), attrs);
+  }
+
+  @Override
+  public void visit(GaugeLong.Stats stats) {
+    Attributes attrs = OtelAttributes.of(stats.tags());
+    getOrCreate(gaugeLongCache, stats.name(), name ->
+        otelMeter.gaugeBuilder(name)
+            .ofLongs()
+            .setUnit("1")
+            .build()
+    ).set(stats.value(), attrs);
+  }
+
+  private void recordMeterStats(Meter.Stats stats, String unit) {
+    Attributes attrs = OtelAttributes.of(stats.tags());
+    String name = stats.name();
+
+    getOrCreate(meterCountCache, name, n ->
+        otelMeter.counterBuilder(n + ".count")
+            .setUnit("{event}")
+            .build()
+    ).add(stats.count(), attrs);
+
+    getOrCreate(meterTotalCache, name, n ->
+        otelMeter.counterBuilder(n + ".total")
+            .setUnit(unit)
+            .build()
+    ).add(stats.total(), attrs);
+
+    getOrCreate(meterMaxCache, name, n ->
+        otelMeter.gaugeBuilder(n + ".max")
+            .ofLongs()
+            .setUnit(unit)
+            .build()
+    ).set(stats.max(), attrs);
+  }
+
+  private <T> T getOrCreate(ConcurrentHashMap<String, T> cache, String name, Function<String, T> factory) {
+    return cache.computeIfAbsent(name, factory);
+  }
+}

--- a/metrics-otel/src/main/java/module-info.java
+++ b/metrics-otel/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module io.avaje.metrics.otel {
+
+  exports io.avaje.metrics.otel;
+
+  requires io.avaje.applog;
+  requires io.avaje.metrics;
+  requires static io.opentelemetry.api;
+}

--- a/metrics-otel/src/test/java/io/avaje/metrics/otel/OtelAttributesTest.java
+++ b/metrics-otel/src/test/java/io/avaje/metrics/otel/OtelAttributesTest.java
@@ -1,0 +1,65 @@
+package io.avaje.metrics.otel;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtelAttributesTest {
+
+  @Test
+  void nullTags_returnsEmpty() {
+    assertThat(OtelAttributes.of(null)).isEqualTo(Attributes.empty());
+  }
+
+  @Test
+  void emptyTags_returnsEmpty() {
+    assertThat(OtelAttributes.of(new String[0])).isEqualTo(Attributes.empty());
+  }
+
+  @Test
+  void singleTag() {
+    Attributes attrs = OtelAttributes.of(new String[]{"env:prod"});
+    assertThat(attrs.get(AttributeKey.stringKey("env"))).isEqualTo("prod");
+    assertThat(attrs.size()).isEqualTo(1);
+  }
+
+  @Test
+  void multipleTags() {
+    Attributes attrs = OtelAttributes.of(new String[]{"env:prod", "region:us-east-1", "tier:backend"});
+    assertThat(attrs.get(AttributeKey.stringKey("env"))).isEqualTo("prod");
+    assertThat(attrs.get(AttributeKey.stringKey("region"))).isEqualTo("us-east-1");
+    assertThat(attrs.get(AttributeKey.stringKey("tier"))).isEqualTo("backend");
+    assertThat(attrs.size()).isEqualTo(3);
+  }
+
+  @Test
+  void tagWithoutColon_skipped() {
+    Attributes attrs = OtelAttributes.of(new String[]{"badtag", "env:prod"});
+    assertThat(attrs.size()).isEqualTo(1);
+    assertThat(attrs.get(AttributeKey.stringKey("env"))).isEqualTo("prod");
+  }
+
+  @Test
+  void tagWithColonAtStart_skipped() {
+    // colon at index 0 — key would be empty
+    Attributes attrs = OtelAttributes.of(new String[]{":value", "env:prod"});
+    assertThat(attrs.size()).isEqualTo(1);
+    assertThat(attrs.get(AttributeKey.stringKey("env"))).isEqualTo("prod");
+  }
+
+  @Test
+  void tagWithValueContainingColon() {
+    // value contains extra colon — split on first colon only
+    Attributes attrs = OtelAttributes.of(new String[]{"url:http://example.com"});
+    assertThat(attrs.get(AttributeKey.stringKey("url"))).isEqualTo("http://example.com");
+  }
+
+  @Test
+  void nullTagEntry_skipped() {
+    Attributes attrs = OtelAttributes.of(new String[]{null, "env:prod"});
+    assertThat(attrs.size()).isEqualTo(1);
+    assertThat(attrs.get(AttributeKey.stringKey("env"))).isEqualTo("prod");
+  }
+}

--- a/metrics-otel/src/test/java/io/avaje/metrics/otel/OtelReporterTest.java
+++ b/metrics-otel/src/test/java/io/avaje/metrics/otel/OtelReporterTest.java
@@ -1,0 +1,207 @@
+package io.avaje.metrics.otel;
+
+import io.avaje.metrics.*;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.data.LongPointData;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.testing.exporter.InMemoryMetricReader;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OtelReporterTest {
+
+  InMemoryMetricReader reader;
+  SdkMeterProvider sdkMeterProvider;
+  OpenTelemetrySdk openTelemetry;
+  MetricRegistry registry;
+  OtelReporter reporter;
+
+  @BeforeEach
+  void setup() {
+    reader = InMemoryMetricReader.create();
+    sdkMeterProvider = SdkMeterProvider.builder()
+        .registerMetricReader(reader)
+        .build();
+    openTelemetry = OpenTelemetrySdk.builder()
+        .setMeterProvider(sdkMeterProvider)
+        .build();
+    registry = Metrics.createRegistry();
+    reporter = OtelReporter.builder()
+        .openTelemetry(openTelemetry)
+        .registry(registry)
+        .build();
+  }
+
+  @AfterEach
+  void teardown() {
+    reporter.close();
+    sdkMeterProvider.close();
+  }
+
+  @Test
+  void counter() {
+    Counter counter = registry.counter("app.login.count");
+    counter.inc(5);
+    counter.inc(3);
+
+    reporter.report();
+
+    Map<String, MetricData> metrics = collectByName();
+    assertThat(metrics).containsKey("app.login.count");
+    MetricData data = metrics.get("app.login.count");
+    assertThat(data.getLongSumData().getPoints()).hasSize(1);
+    LongPointData point = data.getLongSumData().getPoints().iterator().next();
+    assertThat(point.getValue()).isEqualTo(8);
+  }
+
+  @Test
+  void counter_withTags() {
+    Counter counter = registry.counter("app.login.count", Tags.of("env:prod", "region:us-east"));
+    counter.inc(10);
+
+    reporter.report();
+
+    Map<String, MetricData> metrics = collectByName();
+    assertThat(metrics).containsKey("app.login.count");
+    MetricData data = metrics.get("app.login.count");
+    LongPointData point = data.getLongSumData().getPoints().iterator().next();
+    assertThat(point.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("env"))).isEqualTo("prod");
+    assertThat(point.getAttributes().get(io.opentelemetry.api.common.AttributeKey.stringKey("region"))).isEqualTo("us-east");
+  }
+
+  @Test
+  void counter_zeroNotReported() {
+    registry.counter("app.noop.count");
+    // no increments
+
+    reporter.report();
+
+    Map<String, MetricData> metrics = collectByName();
+    assertThat(metrics).doesNotContainKey("app.noop.count");
+  }
+
+  @Test
+  void timer() {
+    Timer timer = registry.timer("app.service.method");
+    timer.addEventDuration(true, 5_000_000L);   // 5ms = 5000 micros
+    timer.addEventDuration(true, 10_000_000L);  // 10ms = 10000 micros
+
+    reporter.report();
+
+    Map<String, MetricData> metrics = collectByName();
+    assertThat(metrics).containsKey("app.service.method.count");
+    assertThat(metrics).containsKey("app.service.method.total");
+    assertThat(metrics).containsKey("app.service.method.max");
+
+    LongPointData count = metrics.get("app.service.method.count").getLongSumData().getPoints().iterator().next();
+    assertThat(count.getValue()).isEqualTo(2);
+
+    LongPointData total = metrics.get("app.service.method.total").getLongSumData().getPoints().iterator().next();
+    assertThat(total.getValue()).isEqualTo(15_000L); // 5000 + 10000 micros
+  }
+
+  @Test
+  void timer_errorSeparateInstruments() {
+    Timer timer = registry.timer("app.service.method");
+    timer.addEventDuration(true, 5_000_000L);
+    timer.addEventDuration(false, 2_000_000L);  // error
+
+    reporter.report();
+
+    Map<String, MetricData> metrics = collectByName();
+    // success instruments
+    assertThat(metrics).containsKey("app.service.method.count");
+    // error instruments (avaje appends .error to the name)
+    assertThat(metrics).containsKey("app.service.method.error.count");
+  }
+
+  @Test
+  void timer_threshold_skipped() {
+    reporter.close();
+    reporter = OtelReporter.builder()
+        .openTelemetry(openTelemetry)
+        .registry(registry)
+        .timedThresholdMicros(10_000)  // 10ms threshold
+        .build();
+
+    Timer timer = registry.timer("app.fast.method");
+    timer.addEventDuration(true, 1_000_000L);  // 1ms — below threshold
+
+    reporter.report();
+
+    Map<String, MetricData> metrics = collectByName();
+    assertThat(metrics).doesNotContainKey("app.fast.method.count");
+  }
+
+  @Test
+  void meter() {
+    Meter meter = registry.meter("app.bytes.sent");
+    meter.addEvent(1024);
+    meter.addEvent(2048);
+
+    reporter.report();
+
+    Map<String, MetricData> metrics = collectByName();
+    assertThat(metrics).containsKey("app.bytes.sent.count");
+    assertThat(metrics).containsKey("app.bytes.sent.total");
+    assertThat(metrics).containsKey("app.bytes.sent.max");
+
+    LongPointData count = metrics.get("app.bytes.sent.count").getLongSumData().getPoints().iterator().next();
+    assertThat(count.getValue()).isEqualTo(2);
+
+    LongPointData total = metrics.get("app.bytes.sent.total").getLongSumData().getPoints().iterator().next();
+    assertThat(total.getValue()).isEqualTo(3072L);
+  }
+
+  @Test
+  void gaugeLong() {
+    registry.gauge("jvm.threads.active", () -> 42L);
+
+    reporter.report();
+
+    Map<String, MetricData> metrics = collectByName();
+    assertThat(metrics).containsKey("jvm.threads.active");
+    long value = metrics.get("jvm.threads.active").getLongGaugeData().getPoints().iterator().next().getValue();
+    assertThat(value).isEqualTo(42L);
+  }
+
+  @Test
+  void gaugeDouble() {
+    registry.gauge("jvm.memory.pct", () -> 0.75);
+
+    reporter.report();
+
+    Map<String, MetricData> metrics = collectByName();
+    assertThat(metrics).containsKey("jvm.memory.pct");
+    double value = metrics.get("jvm.memory.pct").getDoubleGaugeData().getPoints().iterator().next().getValue();
+    assertThat(value).isEqualTo(0.75);
+  }
+
+  @Test
+  void multipleReportCycles_counterAccumulates() {
+    Counter counter = registry.counter("app.requests");
+
+    counter.inc(5);
+    reporter.report();
+    counter.inc(3);
+    reporter.report();
+
+    Map<String, MetricData> metrics = collectByName();
+    LongPointData point = metrics.get("app.requests").getLongSumData().getPoints().iterator().next();
+    // OTEL SDK accumulates deltas: 5 + 3 = 8 total
+    assertThat(point.getValue()).isEqualTo(8);
+  }
+
+  private Map<String, MetricData> collectByName() {
+    Collection<MetricData> all = reader.collectAllMetrics();
+    return all.stream().collect(Collectors.toMap(MetricData::getName, m -> m));
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <module>metrics-graphite</module>
     <module>metrics-ebean</module>
     <module>metrics-statsd</module>
+    <module>metrics-otel</module>
   </modules>
 
 </project>


### PR DESCRIPTION
This adapts avaje metrics into OTEL metrics and publishes those (delta) metrics into OTEL on a periodic basis (typically publish every 60 seconds).

The OTEL exporter, with then export all the OTEL metrics and traces etc.