### PR TITLE
Add CollectionMode.CUMULATIVE for Prometheus style cumulative metrics

### DIFF
--- a/metrics-ebean/src/main/java/io/avaje/metrics/ebean/DatabaseMetricSupplier.java
+++ b/metrics-ebean/src/main/java/io/avaje/metrics/ebean/DatabaseMetricSupplier.java
@@ -1,15 +1,13 @@
 package io.avaje.metrics.ebean;
 
 import io.avaje.applog.AppLog;
+import io.avaje.metrics.CollectionMode;
 import io.avaje.metrics.Metric;
 import io.avaje.metrics.MetricSupplier;
 import io.avaje.metrics.stats.CounterStats;
 import io.avaje.metrics.stats.TimerStats;
 import io.ebean.Database;
-import io.ebean.meta.MetaCountMetric;
-import io.ebean.meta.MetaQueryMetric;
-import io.ebean.meta.MetaTimedMetric;
-import io.ebean.meta.ServerMetrics;
+import io.ebean.meta.*;
 
 import java.lang.System.Logger.Level;
 import java.util.ArrayList;
@@ -30,8 +28,17 @@ public final class DatabaseMetricSupplier implements MetricSupplier {
 
   @Override
   public List<Metric.Statistics> collectMetrics() {
+    return collectMetrics(CollectionMode.DELTA);
+  }
+
+  @Override
+  public List<Metric.Statistics> collectMetrics(CollectionMode mode) {
+    boolean reset = mode == CollectionMode.DELTA;
+
+    var dbMetrics = new BasicMetricVisitor(database.name(), MetricNamingMatch.INSTANCE, reset, true, true, true);
+    database.metaInfo().visitMetrics(dbMetrics);
+
     List<Metric.Statistics> metrics = new ArrayList<>();
-    ServerMetrics dbMetrics = database.metaInfo().collectMetrics();
     if (log.isLoggable(Level.DEBUG)) {
       log.log(Level.DEBUG, dbMetrics.asJson().withHash(false).withNewLine(false).json());
     }

--- a/metrics-otel-producer/README.md
+++ b/metrics-otel-producer/README.md
@@ -4,8 +4,10 @@ Exposes [avaje-metrics](https://avaje-metrics.github.io) to OpenTelemetry using 
 `MetricProducer` bridge.
 
 Unlike `avaje-metrics-otel`, this module does not run its own reporting schedule. Metric collection
-happens when the OpenTelemetry SDK reader/exporter collects, so interval boundaries align with the
-configured OTLP export interval or Prometheus scrape/reader interval.
+happens when the OpenTelemetry SDK reader/exporter collects.
+
+- counters, `name.count`, and `name.total` are exported as cumulative monotonic sums
+- `name.max` is exported as a gauge and resets on each collection
 
 ## Maven dependency
 
@@ -87,8 +89,8 @@ OtelMetricProducer producer = OtelMetricProducer.builder()
     // Use a non-default MetricRegistry (defaults to Metrics.registry())
     .registry(myRegistry)
 
-    // Skip timer metrics whose total duration is below this threshold.
-    // 1_000 = skip timers with less than 1ms total execution per collection interval.
+    // Skip timer metrics whose cumulative total duration is below this threshold.
+    // 1_000 = skip timers with less than 1ms cumulative execution.
     .timedThresholdMicros(1_000)
 
     // OpenTelemetry instrumentation scope name (default: "io.avaje.metrics")
@@ -103,9 +105,9 @@ avaje metrics are mapped to OTEL metric data as follows:
 
 | avaje type | OTEL metric data | Notes |
 |---|---|---|
-| `Counter` | delta `LongSum` | monotonic, unit `{event}` |
-| `Timer` | delta `LongSum` (`name.count`), delta `LongSum` (`name.total`), `LongGauge` (`name.max`) | values in microseconds (`us`) |
-| `Meter` | delta `LongSum` (`name.count`), delta `LongSum` (`name.total`), `LongGauge` (`name.max`) | values in user-defined units |
+| `Counter` | cumulative `LongSum` | monotonic, unit `{event}` |
+| `Timer` | cumulative `LongSum` (`name.count`), cumulative `LongSum` (`name.total`), `LongGauge` (`name.max`) | count/total are cumulative; `max` resets each collection; values in microseconds (`us`) |
+| `Meter` | cumulative `LongSum` (`name.count`), cumulative `LongSum` (`name.total`), `LongGauge` (`name.max`) | count/total are cumulative; `max` resets each collection |
 | `GaugeLong` | `LongGauge` | current value at collection time |
 | `GaugeDouble` | `DoubleGauge` | current value at collection time |
 
@@ -117,8 +119,9 @@ existing avaje timer reporting behavior.
 Use `avaje-metrics-otel-producer` when you want collection-time intervals controlled by the
 OpenTelemetry SDK reader/exporter, for example:
 
-- OTLP export intervals should define the delta window
-- Prometheus / pull-style collection should define the interval
+- you want Prometheus / Grafana-friendly cumulative sums for count / total
+- OTLP export or Prometheus / pull-style collection should drive when metrics are read
+- you want `name.max` to reflect the current collection window
 - You want to avoid a separate avaje reporting scheduler
 
 Use `avaje-metrics-otel` when you want the lighter API-only scheduled reporter and do not need a
@@ -129,10 +132,13 @@ If you want a convenience module that builds an OTLP-backed `OpenTelemetrySdk` a
 
 ## Important limitation
 
-`MetricProducer.produce(...)` returns metrics produced since the previous collection. That makes
-this bridge effectively a single-reader solution for a given avaje registry/export path. Do not
-register multiple readers against the same `OtelMetricProducer` unless you are prepared for one
-reader to drain the interval before another reads it.
+This bridge should still be treated as a single-reader solution for a given avaje registry/export
+path. Although counters and totals are cumulative, `name.max` resets on collection, so one reader
+can consume the max window before another reads it.
+
+Supplier-backed metrics only behave cumulatively when the supplier implements
+`MetricSupplier.collectMetrics(CollectionMode)`. Some supplier-based integrations, such as
+`avaje-metrics-ebean`, still need a follow-up update for cumulative collection semantics.
 
 Do not use `avaje-metrics-otel` and `avaje-metrics-otel-producer` for the same registry/export
 path at the same time, or you will emit duplicate telemetry.

--- a/metrics-otel-producer/README.md
+++ b/metrics-otel-producer/README.md
@@ -137,8 +137,12 @@ path. Although counters and totals are cumulative, `name.max` resets on collecti
 can consume the max window before another reads it.
 
 Supplier-backed metrics only behave cumulatively when the supplier implements
-`MetricSupplier.collectMetrics(CollectionMode)`. Some supplier-based integrations, such as
-`avaje-metrics-ebean`, still need a follow-up update for cumulative collection semantics.
+`MetricSupplier.collectMetrics(CollectionMode)`.
+
+`avaje-metrics-ebean` now supports both delta and cumulative collection modes. Its cumulative timed
+and query `max` values rely on the corresponding Ebean runtime fix that resets `max` on each
+collection; without that runtime change, cumulative `count` and `total` still work but `max`
+behaves like a lifetime high-water mark.
 
 Do not use `avaje-metrics-otel` and `avaje-metrics-otel-producer` for the same registry/export
 path at the same time, or you will emit duplicate telemetry.

--- a/metrics-otel-producer/src/main/java/io/avaje/metrics/otel/producer/DOtelMetricProducer.java
+++ b/metrics-otel-producer/src/main/java/io/avaje/metrics/otel/producer/DOtelMetricProducer.java
@@ -1,5 +1,6 @@
 package io.avaje.metrics.otel.producer;
 
+import io.avaje.metrics.CollectionMode;
 import io.avaje.metrics.MetricRegistry;
 import io.opentelemetry.sdk.common.InstrumentationScopeInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
@@ -15,7 +16,7 @@ final class DOtelMetricProducer implements OtelMetricProducer {
   private final MetricRegistry registry;
   private final MetricDataMapper mapper;
   private final LongSupplier epochNanosSource;
-  private long lastCollectionEpochNanos;
+  private final long startEpochNanos;
 
   DOtelMetricProducer(
     MetricRegistry registry,
@@ -26,16 +27,14 @@ final class DOtelMetricProducer implements OtelMetricProducer {
     this.registry = requireNonNull(registry, "registry");
     this.mapper = new MetricDataMapper(requireNonNull(scopeInfo, "scopeInfo"), timedThresholdMicros);
     this.epochNanosSource = requireNonNull(epochNanosSource, "epochNanosSource");
-    this.lastCollectionEpochNanos = epochNanosSource.getAsLong();
+    this.startEpochNanos = epochNanosSource.getAsLong();
   }
 
   @Override
   public synchronized Collection<MetricData> produce(Resource resource) {
     requireNonNull(resource, "resource");
-    var startEpochNanos = lastCollectionEpochNanos;
     var epochNanos = epochNanosSource.getAsLong();
-    var statistics = registry.collectMetrics();
-    lastCollectionEpochNanos = epochNanos;
+    var statistics = registry.collectMetrics(CollectionMode.CUMULATIVE);
     return mapper.map(resource, startEpochNanos, epochNanos, statistics);
   }
 }

--- a/metrics-otel-producer/src/main/java/io/avaje/metrics/otel/producer/MetricDataMapper.java
+++ b/metrics-otel-producer/src/main/java/io/avaje/metrics/otel/producer/MetricDataMapper.java
@@ -130,7 +130,7 @@ final class MetricDataMapper {
         unit,
         SumData.createLongSumData(
           monotonic,
-          AggregationTemporality.DELTA,
+          AggregationTemporality.CUMULATIVE,
           List.of(LongPointData.create(startEpochNanos, epochNanos, attributes, value))));
     }
 

--- a/metrics-otel-producer/src/test/java/io/avaje/metrics/otel/producer/OtelMetricProducerTest.java
+++ b/metrics-otel-producer/src/test/java/io/avaje/metrics/otel/producer/OtelMetricProducerTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 class OtelMetricProducerTest {
 
   @Test
-  void counter_deltaAcrossCollections() {
+  void counter_cumulativeAcrossCollections() {
     var epochNanosSource = new MutableEpochNanosSource(epochNanos(Instant.parse("2026-01-01T00:00:00Z")));
     var registry = Metrics.createRegistry();
     var producer = new DOtelMetricProducer(registry, InstrumentationScopeInfo.create("test.scope"), 0, epochNanosSource);
@@ -42,17 +42,25 @@ class OtelMetricProducerTest {
     epochNanosSource.advanceSeconds(10);
     var second = onlyMetric(producer.produce(Resource.empty()));
 
+    epochNanosSource.advanceSeconds(10);
+    var third = onlyMetric(producer.produce(Resource.empty()));
+
     assertThat(first.getName()).isEqualTo("app.requests");
-    assertThat(first.getLongSumData().getAggregationTemporality()).isEqualTo(AggregationTemporality.DELTA);
+    assertThat(first.getLongSumData().getAggregationTemporality()).isEqualTo(AggregationTemporality.CUMULATIVE);
     assertThat(first.getLongSumData().isMonotonic()).isTrue();
     assertThat(onlyLongPoint(first).getStartEpochNanos()).isEqualTo(epochNanos(Instant.parse("2026-01-01T00:00:00Z")));
     assertThat(onlyLongPoint(first).getEpochNanos()).isEqualTo(epochNanos(Instant.parse("2026-01-01T00:00:10Z")));
     assertThat(onlyLongPoint(first).getValue()).isEqualTo(5);
 
     assertThat(second.getName()).isEqualTo("app.requests");
-    assertThat(onlyLongPoint(second).getStartEpochNanos()).isEqualTo(epochNanos(Instant.parse("2026-01-01T00:00:10Z")));
+    assertThat(onlyLongPoint(second).getStartEpochNanos()).isEqualTo(epochNanos(Instant.parse("2026-01-01T00:00:00Z")));
     assertThat(onlyLongPoint(second).getEpochNanos()).isEqualTo(epochNanos(Instant.parse("2026-01-01T00:00:20Z")));
-    assertThat(onlyLongPoint(second).getValue()).isEqualTo(3);
+    assertThat(onlyLongPoint(second).getValue()).isEqualTo(8);
+
+    assertThat(third.getName()).isEqualTo("app.requests");
+    assertThat(onlyLongPoint(third).getStartEpochNanos()).isEqualTo(epochNanos(Instant.parse("2026-01-01T00:00:00Z")));
+    assertThat(onlyLongPoint(third).getEpochNanos()).isEqualTo(epochNanos(Instant.parse("2026-01-01T00:00:30Z")));
+    assertThat(onlyLongPoint(third).getValue()).isEqualTo(8);
   }
 
   @Test
@@ -73,7 +81,7 @@ class OtelMetricProducerTest {
   }
 
   @Test
-  void timer_metricsIncludeSuccessAndErrorSeries() {
+  void timer_metricsAreCumulativeAndMaxResets() {
     var epochNanosSource = new MutableEpochNanosSource(epochNanos(Instant.parse("2026-01-01T00:00:00Z")));
     var registry = Metrics.createRegistry();
     var producer = new DOtelMetricProducer(registry, InstrumentationScopeInfo.create("test.scope"), 0, epochNanosSource);
@@ -83,9 +91,9 @@ class OtelMetricProducerTest {
     timer.addEventDuration(false, 2_000_000L);
     epochNanosSource.advanceSeconds(5);
 
-    Map<String, MetricData> metrics = byName(producer.produce(Resource.empty()));
+    Map<String, MetricData> first = byName(producer.produce(Resource.empty()));
 
-    assertThat(metrics).containsKeys(
+    assertThat(first).containsKeys(
       "app.service.method.count",
       "app.service.method.total",
       "app.service.method.max",
@@ -93,16 +101,44 @@ class OtelMetricProducerTest {
       "app.service.method.error.total",
       "app.service.method.error.max");
 
-    assertThat(onlyLongSumPoint(metrics.get("app.service.method.count")).getValue()).isEqualTo(1);
-    assertThat(onlyLongSumPoint(metrics.get("app.service.method.total")).getValue()).isEqualTo(5_000L);
-    assertThat(onlyLongGaugePoint(metrics.get("app.service.method.max")).getValue()).isEqualTo(5_000L);
-    assertThat(onlyLongSumPoint(metrics.get("app.service.method.error.count")).getValue()).isEqualTo(1);
-    assertThat(onlyLongSumPoint(metrics.get("app.service.method.error.total")).getValue()).isEqualTo(2_000L);
-    assertThat(onlyLongGaugePoint(metrics.get("app.service.method.error.max")).getValue()).isEqualTo(2_000L);
+    assertThat(first.get("app.service.method.count").getLongSumData().getAggregationTemporality())
+      .isEqualTo(AggregationTemporality.CUMULATIVE);
+    assertThat(onlyLongSumPoint(first.get("app.service.method.count")).getStartEpochNanos())
+      .isEqualTo(epochNanos(Instant.parse("2026-01-01T00:00:00Z")));
+    assertThat(onlyLongSumPoint(first.get("app.service.method.count")).getEpochNanos())
+      .isEqualTo(epochNanos(Instant.parse("2026-01-01T00:00:05Z")));
+    assertThat(onlyLongSumPoint(first.get("app.service.method.count")).getValue()).isEqualTo(1);
+    assertThat(onlyLongSumPoint(first.get("app.service.method.total")).getValue()).isEqualTo(5_000L);
+    assertThat(onlyLongGaugePoint(first.get("app.service.method.max")).getValue()).isEqualTo(5_000L);
+    assertThat(onlyLongSumPoint(first.get("app.service.method.error.count")).getValue()).isEqualTo(1);
+    assertThat(onlyLongSumPoint(first.get("app.service.method.error.total")).getValue()).isEqualTo(2_000L);
+    assertThat(onlyLongGaugePoint(first.get("app.service.method.error.max")).getValue()).isEqualTo(2_000L);
+
+    epochNanosSource.advanceSeconds(5);
+    Map<String, MetricData> second = byName(producer.produce(Resource.empty()));
+
+    assertThat(onlyLongSumPoint(second.get("app.service.method.count")).getValue()).isEqualTo(1);
+    assertThat(onlyLongSumPoint(second.get("app.service.method.total")).getValue()).isEqualTo(5_000L);
+    assertThat(onlyLongGaugePoint(second.get("app.service.method.max")).getValue()).isEqualTo(0L);
+    assertThat(onlyLongSumPoint(second.get("app.service.method.error.count")).getValue()).isEqualTo(1);
+    assertThat(onlyLongSumPoint(second.get("app.service.method.error.total")).getValue()).isEqualTo(2_000L);
+    assertThat(onlyLongGaugePoint(second.get("app.service.method.error.max")).getValue()).isEqualTo(0L);
+
+    timer.addEventDuration(true, 3_000_000L);
+    timer.addEventDuration(false, 7_000_000L);
+    epochNanosSource.advanceSeconds(5);
+    Map<String, MetricData> third = byName(producer.produce(Resource.empty()));
+
+    assertThat(onlyLongSumPoint(third.get("app.service.method.count")).getValue()).isEqualTo(2);
+    assertThat(onlyLongSumPoint(third.get("app.service.method.total")).getValue()).isEqualTo(8_000L);
+    assertThat(onlyLongGaugePoint(third.get("app.service.method.max")).getValue()).isEqualTo(3_000L);
+    assertThat(onlyLongSumPoint(third.get("app.service.method.error.count")).getValue()).isEqualTo(2);
+    assertThat(onlyLongSumPoint(third.get("app.service.method.error.total")).getValue()).isEqualTo(9_000L);
+    assertThat(onlyLongGaugePoint(third.get("app.service.method.error.max")).getValue()).isEqualTo(7_000L);
   }
 
   @Test
-  void timedThreshold_skipsSmallTimers() {
+  void timedThreshold_appliesToCumulativeTotal() {
     var epochNanosSource = new MutableEpochNanosSource(epochNanos(Instant.parse("2026-01-01T00:00:00Z")));
     var registry = Metrics.createRegistry();
     var producer = new DOtelMetricProducer(registry, InstrumentationScopeInfo.create("test.scope"), 10_000, epochNanosSource);
@@ -112,6 +148,15 @@ class OtelMetricProducerTest {
     epochNanosSource.advanceSeconds(5);
 
     assertThat(producer.produce(Resource.empty())).isEmpty();
+
+    timer.addEventDuration(true, 9_000_000L);
+    epochNanosSource.advanceSeconds(5);
+
+    Map<String, MetricData> metrics = byName(producer.produce(Resource.empty()));
+
+    assertThat(onlyLongSumPoint(metrics.get("app.fast.method.count")).getValue()).isEqualTo(2);
+    assertThat(onlyLongSumPoint(metrics.get("app.fast.method.total")).getValue()).isEqualTo(10_000L);
+    assertThat(onlyLongGaugePoint(metrics.get("app.fast.method.max")).getValue()).isEqualTo(9_000L);
   }
 
   @Test
@@ -129,6 +174,8 @@ class OtelMetricProducerTest {
 
     Map<String, MetricData> metrics = byName(producer.produce(Resource.empty()));
 
+    assertThat(metrics.get("app.bytes.sent.count").getLongSumData().getAggregationTemporality())
+      .isEqualTo(AggregationTemporality.CUMULATIVE);
     assertThat(onlyLongSumPoint(metrics.get("app.bytes.sent.count")).getValue()).isEqualTo(2);
     assertThat(onlyLongSumPoint(metrics.get("app.bytes.sent.total")).getValue()).isEqualTo(3072L);
     assertThat(onlyLongGaugePoint(metrics.get("app.bytes.sent.max")).getValue()).isEqualTo(2048L);
@@ -155,6 +202,7 @@ class OtelMetricProducerTest {
       MetricData metric = onlyMetric(reader.collectAllMetrics());
 
       assertThat(metric.getName()).isEqualTo("app.checkout");
+      assertThat(metric.getLongSumData().getAggregationTemporality()).isEqualTo(AggregationTemporality.CUMULATIVE);
       assertThat(metric.getInstrumentationScopeInfo().getName()).isEqualTo("custom.scope");
       assertThat(metric.getResource().getAttribute(AttributeKey.stringKey("service.name"))).isEqualTo("catalog");
       assertThat(onlyLongPoint(metric).getValue()).isEqualTo(4);

--- a/metrics/src/main/java/io/avaje/metrics/CollectionMode.java
+++ b/metrics/src/main/java/io/avaje/metrics/CollectionMode.java
@@ -11,7 +11,9 @@ public enum CollectionMode {
   DELTA,
 
   /**
-   * Collect process-lifetime values without resetting the underlying counters.
+   * Collect process-lifetime count and total values without resetting them.
+   *
+   * <p>Windowed high-water values such as {@code max} may still reset on each collection.
    */
   CUMULATIVE
 }

--- a/metrics/src/main/java/io/avaje/metrics/CollectionMode.java
+++ b/metrics/src/main/java/io/avaje/metrics/CollectionMode.java
@@ -1,0 +1,17 @@
+package io.avaje.metrics;
+
+/**
+ * The collection mode used when reading metric statistics.
+ */
+public enum CollectionMode {
+
+  /**
+   * Collect the current interval values and reset the underlying counters.
+   */
+  DELTA,
+
+  /**
+   * Collect process-lifetime values without resetting the underlying counters.
+   */
+  CUMULATIVE
+}

--- a/metrics/src/main/java/io/avaje/metrics/Metric.java
+++ b/metrics/src/main/java/io/avaje/metrics/Metric.java
@@ -25,8 +25,12 @@ public interface Metric {
   String name();
 
   /**
-   * Typically this is only called by the MetricManager and tells the metric to collect its underlying statistics for
-   * reporting purposes and in addition resetting and internal counters it has.
+   * Typically this is only called by the MetricManager and tells the metric to collect its underlying
+   * statistics for reporting purposes.
+   * <p>
+   * The {@link Visitor#collectionMode()} determines whether the collect operation also resets any
+   * internal counters.
+   * </p>
    */
   void collect(Visitor collector);
 
@@ -121,6 +125,13 @@ public interface Metric {
      */
     default Function<String, String> namingConvention() {
       return NamingMatch.INSTANCE;
+    }
+
+    /**
+     * Return the collection mode to use when gathering metric statistics.
+     */
+    default CollectionMode collectionMode() {
+      return CollectionMode.DELTA;
     }
 
     /**

--- a/metrics/src/main/java/io/avaje/metrics/MetricRegistry.java
+++ b/metrics/src/main/java/io/avaje/metrics/MetricRegistry.java
@@ -135,14 +135,26 @@ public interface MetricRegistry extends JvmMetrics {
   MetricRegistry namingUnderscore();
 
   /**
-   * Collect all the metrics.
+   * Collect all the metrics using {@link CollectionMode#DELTA}.
    */
   List<Metric.Statistics> collectMetrics();
 
   /**
-   * Collect the metrics for writing as JSON (typically to a supplied Appender).
+   * Collect all the metrics using the given collection mode.
+   */
+  List<Metric.Statistics> collectMetrics(CollectionMode mode);
+
+  /**
+   * Collect the metrics for writing as JSON using {@link CollectionMode#DELTA}
+   * (typically to a supplied Appender).
    */
   JsonMetrics collectAsJson();
+
+  /**
+   * Collect the metrics for writing as JSON using the given collection mode
+   * (typically to a supplied Appender).
+   */
+  JsonMetrics collectAsJson(CollectionMode mode);
 
   /**
    * Write the collected metrics in JSON form.

--- a/metrics/src/main/java/io/avaje/metrics/MetricSupplier.java
+++ b/metrics/src/main/java/io/avaje/metrics/MetricSupplier.java
@@ -11,4 +11,12 @@ public interface MetricSupplier {
    * Return extra metrics that should be included in metrics reporting.
    */
   List<Metric.Statistics> collectMetrics();
+
+  /**
+   * Return extra metrics that should be included in metrics reporting for the
+   * given collection mode.
+   */
+  default List<Metric.Statistics> collectMetrics(CollectionMode mode) {
+    return collectMetrics();
+  }
 }

--- a/metrics/src/main/java/io/avaje/metrics/Metrics.java
+++ b/metrics/src/main/java/io/avaje/metrics/Metrics.java
@@ -46,17 +46,34 @@ public class Metrics {
   }
 
   /**
-   * Collect all the metrics from the default registry.
+   * Collect all the metrics from the default registry using
+   * {@link CollectionMode#DELTA}.
    */
   public static List<Metric.Statistics> collectMetrics() {
-    return defaultRegistry.collectMetrics();
+    return collectMetrics(CollectionMode.DELTA);
   }
 
   /**
-   * Collect the metrics for writing as JSON (typically to a supplied Appender).
+   * Collect all the metrics from the default registry using the given mode.
+   */
+  public static List<Metric.Statistics> collectMetrics(CollectionMode mode) {
+    return defaultRegistry.collectMetrics(mode);
+  }
+
+  /**
+   * Collect the metrics for writing as JSON using
+   * {@link CollectionMode#DELTA} (typically to a supplied Appender).
    */
   public static MetricRegistry.JsonMetrics collectAsJson() {
-    return defaultRegistry.collectAsJson();
+    return collectAsJson(CollectionMode.DELTA);
+  }
+
+  /**
+   * Collect the metrics for writing as JSON using the given mode
+   * (typically to a supplied Appender).
+   */
+  public static MetricRegistry.JsonMetrics collectAsJson(CollectionMode mode) {
+    return defaultRegistry.collectAsJson(mode);
   }
 
   /**

--- a/metrics/src/main/java/io/avaje/metrics/core/DCounter.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DCounter.java
@@ -1,5 +1,6 @@
 package io.avaje.metrics.core;
 
+import io.avaje.metrics.CollectionMode;
 import io.avaje.metrics.Counter;
 import io.avaje.metrics.stats.CounterStats;
 
@@ -40,7 +41,9 @@ final class DCounter extends BaseReportName implements Counter {
 
   @Override
   public void collect(Visitor collector) {
-    final long sum = count.sumThenReset();
+    final long sum = (collector.collectionMode() == CollectionMode.CUMULATIVE)
+      ? count.sum()
+      : count.sumThenReset();
     if (sum != 0) {
       final ID reportId = reportId(collector);
       collector.visit(new CounterStats(reportId, sum));

--- a/metrics/src/main/java/io/avaje/metrics/core/DStatsCollector.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DStatsCollector.java
@@ -10,10 +10,16 @@ import java.util.function.Function;
 final class DStatsCollector implements Metric.Visitor {
 
   private final List<Metric.Statistics> list = new ArrayList<>();
-  private final  Function<String, String> namingConvention;
+  private final Function<String, String> namingConvention;
+  private final CollectionMode collectionMode;
 
   public DStatsCollector(Function<String, String> namingConvention) {
+    this(namingConvention, CollectionMode.DELTA);
+  }
+
+  public DStatsCollector(Function<String, String> namingConvention, CollectionMode collectionMode) {
     this.namingConvention = namingConvention;
+    this.collectionMode = collectionMode;
   }
 
   List<Metric.Statistics> list() {
@@ -23,6 +29,11 @@ final class DStatsCollector implements Metric.Visitor {
   @Override
   public Function<String, String> namingConvention() {
     return namingConvention;
+  }
+
+  @Override
+  public CollectionMode collectionMode() {
+    return collectionMode;
   }
 
   @Override

--- a/metrics/src/main/java/io/avaje/metrics/core/DefaultMetricProvider.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DefaultMetricProvider.java
@@ -333,8 +333,13 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
 
   @Override
   public List<Metric.Statistics> collectMetrics() {
+    return collectMetrics(CollectionMode.DELTA);
+  }
+
+  @Override
+  public List<Metric.Statistics> collectMetrics(CollectionMode mode) {
     synchronized (monitor) {
-      final DStatsCollector collector = new DStatsCollector(namingConvention);
+      final DStatsCollector collector = new DStatsCollector(namingConvention, mode);
       collectAppMetrics(collector);
       return collector.list();
     }
@@ -342,7 +347,12 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
 
   @Override
   public JsonMetrics collectAsJson() {
-    return new DJson(this);
+    return collectAsJson(CollectionMode.DELTA);
+  }
+
+  @Override
+  public JsonMetrics collectAsJson(CollectionMode mode) {
+    return new DJson(this, mode);
   }
 
   private void collectAppMetrics(DStatsCollector collector) {
@@ -350,21 +360,23 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
       metric.collect(collector);
     }
     for (MetricSupplier supplier : suppliers) {
-      collector.addAll(supplier.collectMetrics());
+      collector.addAll(supplier.collectMetrics(collector.collectionMode()));
     }
   }
 
   private static class DJson implements JsonMetrics {
 
     private final DefaultMetricProvider provider;
+    private final CollectionMode mode;
 
-    DJson(DefaultMetricProvider provider) {
+    DJson(DefaultMetricProvider provider, CollectionMode mode) {
       this.provider = provider;
+      this.mode = mode;
     }
 
     @Override
     public void write(Appendable appendable) {
-      JsonWriter.writeTo(appendable, provider.collectMetrics());
+      JsonWriter.writeTo(appendable, provider.collectMetrics(mode));
     }
 
     @Override

--- a/metrics/src/main/java/io/avaje/metrics/core/ValueCounter.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/ValueCounter.java
@@ -1,5 +1,6 @@
 package io.avaje.metrics.core;
 
+import io.avaje.metrics.CollectionMode;
 import io.avaje.metrics.Metric;
 import io.avaje.metrics.Timer;
 import io.avaje.metrics.stats.TimerStats;
@@ -50,12 +51,13 @@ final class ValueCounter extends BaseReportName {
   }
 
   Timer.@Nullable Stats collect(Metric.Visitor collector) {
-    final long count = this.count.sumThenReset();
+    final boolean cumulative = collector.collectionMode() == CollectionMode.CUMULATIVE;
+    final long count = cumulative ? this.count.sum() : this.count.sumThenReset();
     if (count == 0) {
       return null;
     } else {
-      final long maxVal = max.getThenReset();
-      final long totalVal = total.sumThenReset();
+      final long maxVal = cumulative ? max.get() : max.getThenReset();
+      final long totalVal = cumulative ? total.sum() : total.sumThenReset();
       final Metric.ID reportId = reportId(collector);
       return new TimerStats(reportId, bucketRange, count, totalVal, maxVal);
     }

--- a/metrics/src/main/java/io/avaje/metrics/core/ValueCounter.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/ValueCounter.java
@@ -20,7 +20,7 @@ final class ValueCounter extends BaseReportName {
   private final @Nullable String bucketRange;
   private final LongAdder count = new LongAdder();
   private final LongAdder total = new LongAdder();
-  private final LongAccumulator max = new LongAccumulator(Math::max, Long.MIN_VALUE);
+  private final LongAccumulator max = new LongAccumulator(Math::max, 0);
 
   ValueCounter(Metric.ID id) {
     super(id);
@@ -56,8 +56,8 @@ final class ValueCounter extends BaseReportName {
     if (count == 0) {
       return null;
     } else {
-      final long maxVal = cumulative ? max.get() : max.getThenReset();
       final long totalVal = cumulative ? total.sum() : total.sumThenReset();
+      final long maxVal = max.getThenReset();
       final Metric.ID reportId = reportId(collector);
       return new TimerStats(reportId, bucketRange, count, totalVal, maxVal);
     }

--- a/metrics/src/test/java/io/avaje/metrics/MetricsTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/MetricsTest.java
@@ -19,14 +19,24 @@ class MetricsTest {
     Metrics.addSupplier(() -> suppliedMetrics);
     suppliedMetrics.add(new GaugeLongStats(Metric.ID.of("supplied0"), 42));
 
-    List<Metric.Statistics> result = Metrics.collectMetrics();
+    List<Metric.Statistics> result = Metrics.collectMetrics(CollectionMode.CUMULATIVE);
     assertThat(result).hasSize(1);
     assertThat(result.get(0).name()).isEqualTo("supplied0");
 
     suppliedMetrics.clear();
 
-    List<Metric.Statistics> result2 = Metrics.collectMetrics();
+    List<Metric.Statistics> result2 = Metrics.collectMetrics(CollectionMode.CUMULATIVE);
     assertThat(result2).isEmpty();
   }
 
+  @Test
+  void metricSupplier_collectionModeDefaultDelegates() {
+    MetricSupplier supplier = () -> suppliedMetrics;
+    suppliedMetrics.add(new GaugeLongStats(Metric.ID.of("supplied1"), 24));
+
+    assertThat(supplier.collectMetrics(CollectionMode.CUMULATIVE))
+      .singleElement()
+      .extracting(Metric.Statistics::name)
+      .isEqualTo("supplied1");
+  }
 }

--- a/metrics/src/test/java/io/avaje/metrics/core/CollectAsJsonTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/CollectAsJsonTest.java
@@ -74,4 +74,22 @@ class CollectAsJsonTest {
     assertThat(delta).contains("{\"name\":\"my.cumulative.count\",\"value\":2}");
     assertThat(registry.collectAsJson().asJson()).doesNotContain("{\"name\":\"my.cumulative.count\"");
   }
+
+  @Test
+  void collectAsJsonCumulative_maxResets() {
+
+    Meter meter = registry.meter("my.cumulative.meter");
+    meter.addEvent(40);
+    meter.addEvent(50);
+
+    String first = registry.collectAsJson(CollectionMode.CUMULATIVE).asJson();
+    assertThat(first).contains("{\"name\":\"my.cumulative.meter\",\"count\":2,\"mean\":45,\"max\":50,\"total\":90}");
+
+    String second = registry.collectAsJson(CollectionMode.CUMULATIVE).asJson();
+    assertThat(second).contains("{\"name\":\"my.cumulative.meter\",\"count\":2,\"mean\":45,\"max\":0,\"total\":90}");
+
+    meter.addEvent(30);
+    String third = registry.collectAsJson(CollectionMode.CUMULATIVE).asJson();
+    assertThat(third).contains("{\"name\":\"my.cumulative.meter\",\"count\":3,\"mean\":40,\"max\":30,\"total\":120}");
+  }
 }

--- a/metrics/src/test/java/io/avaje/metrics/core/CollectAsJsonTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/CollectAsJsonTest.java
@@ -56,4 +56,22 @@ class CollectAsJsonTest {
     assertThat(asJson).contains("{\"name\":\"my.gauge1\",\"value\":200}");
     assertThat(asJson).contains("{\"name\":\"my.gauge1\",\"value\":400,\"tags\":[\"a\",\"b\"]}");
   }
+
+  @Test
+  void collectAsJsonCumulative() {
+
+    Counter counter = registry.counter("my.cumulative.count");
+    counter.inc();
+    counter.inc();
+
+    String first = registry.collectAsJson(CollectionMode.CUMULATIVE).asJson();
+    assertThat(first).contains("{\"name\":\"my.cumulative.count\",\"value\":2}");
+
+    String second = registry.collectAsJson(CollectionMode.CUMULATIVE).asJson();
+    assertThat(second).contains("{\"name\":\"my.cumulative.count\",\"value\":2}");
+
+    String delta = registry.collectAsJson().asJson();
+    assertThat(delta).contains("{\"name\":\"my.cumulative.count\",\"value\":2}");
+    assertThat(registry.collectAsJson().asJson()).doesNotContain("{\"name\":\"my.cumulative.count\"");
+  }
 }

--- a/metrics/src/test/java/io/avaje/metrics/core/CounterMetricTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/CounterMetricTest.java
@@ -33,12 +33,6 @@ class CounterMetricTest {
     assertEquals(0, counterMetric.count());
   }
 
-  private List<Metric.Statistics> collect(Metric metric) {
-    DStatsCollector collector = new DStatsCollector(NamingMatch.INSTANCE);
-    metric.collect(collector);
-    return collector.list();
-  }
-
   @Test
   void tags() {
     MetricRegistry registry = Metrics.registry();
@@ -76,5 +70,39 @@ class CounterMetricTest {
     assertThat(counter0.count()).isEqualTo(0);
     assertThat(counter1.count()).isEqualTo(0);
     assertThat(counter2.count()).isEqualTo(0);
+  }
+
+  @Test
+  void collectCumulative() {
+    DCounter counterMetric = new DCounter(Metric.ID.of("org.test.mycountermetric.cumulative"));
+    counterMetric.inc();
+    counterMetric.inc();
+
+    List<Metric.Statistics> stats = collect(counterMetric, CollectionMode.CUMULATIVE);
+    assertThat(stats).hasSize(1);
+    assertThat(((Counter.Stats) stats.get(0)).count()).isEqualTo(2);
+    assertThat(counterMetric.count()).isEqualTo(2);
+
+    List<Metric.Statistics> stats2 = collect(counterMetric, CollectionMode.CUMULATIVE);
+    assertThat(stats2).hasSize(1);
+    assertThat(((Counter.Stats) stats2.get(0)).count()).isEqualTo(2);
+    assertThat(counterMetric.count()).isEqualTo(2);
+
+    List<Metric.Statistics> stats3 = collect(counterMetric);
+    assertThat(stats3).hasSize(1);
+    assertThat(((Counter.Stats) stats3.get(0)).count()).isEqualTo(2);
+    assertThat(counterMetric.count()).isEqualTo(0);
+  }
+
+  private List<Metric.Statistics> collect(Metric metric) {
+    DStatsCollector collector = new DStatsCollector(NamingMatch.INSTANCE);
+    metric.collect(collector);
+    return collector.list();
+  }
+
+  private List<Metric.Statistics> collect(Metric metric, CollectionMode mode) {
+    DStatsCollector collector = new DStatsCollector(NamingMatch.INSTANCE, mode);
+    metric.collect(collector);
+    return collector.list();
   }
 }

--- a/metrics/src/test/java/io/avaje/metrics/core/CreateRegistryTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/CreateRegistryTest.java
@@ -1,5 +1,6 @@
 package io.avaje.metrics.core;
 
+import io.avaje.metrics.CollectionMode;
 import io.avaje.metrics.Counter;
 import io.avaje.metrics.Metric;
 import io.avaje.metrics.MetricRegistry;
@@ -44,5 +45,32 @@ class CreateRegistryTest {
     List<Metric.Statistics> stats2 = registry.collectMetrics();
     assertThat(stats2).hasSize(1);
     assertThat(stats2.get(0).name()).isEqualTo("create_newRegistry_counter");
+  }
+
+  @Test
+  void createNewRegistry_cumulative() {
+
+    MetricRegistry registry = Metrics.createRegistry();
+    registry.namingUnderscore();
+
+    Counter counterMetric = registry.counter("create.newRegistry.cumulative");
+    counterMetric.inc();
+    counterMetric.inc();
+
+    List<Metric.Statistics> stats = registry.collectMetrics(CollectionMode.CUMULATIVE);
+    assertThat(stats).hasSize(1);
+    assertThat(stats.get(0).name()).isEqualTo("create_newRegistry_cumulative");
+    assertThat(((Counter.Stats) stats.get(0)).count()).isEqualTo(2);
+    assertThat(counterMetric.count()).isEqualTo(2);
+
+    List<Metric.Statistics> stats2 = registry.collectMetrics(CollectionMode.CUMULATIVE);
+    assertThat(stats2).hasSize(1);
+    assertThat(((Counter.Stats) stats2.get(0)).count()).isEqualTo(2);
+    assertThat(counterMetric.count()).isEqualTo(2);
+
+    List<Metric.Statistics> stats3 = registry.collectMetrics();
+    assertThat(stats3).hasSize(1);
+    assertThat(((Counter.Stats) stats3.get(0)).count()).isEqualTo(2);
+    assertThat(counterMetric.count()).isEqualTo(0);
   }
 }

--- a/metrics/src/test/java/io/avaje/metrics/core/DBucketTimerTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/DBucketTimerTest.java
@@ -81,13 +81,24 @@ class DBucketTimerTest {
     Timer.Stats stats = collectTimer(bucket, CollectionMode.CUMULATIVE);
     assertEquals(1, stats.count());
     assertEquals(50_000, stats.total());
+    assertEquals(50_000, stats.max());
 
     Timer.Stats stats2 = collectTimer(bucket, CollectionMode.CUMULATIVE);
     assertEquals(1, stats2.count());
     assertEquals(50_000, stats2.total());
+    assertEquals(0, stats2.max());
+
+    long fortyMillisAsNanos = TimeUnit.MILLISECONDS.toNanos(40);
+    bucketTimedMetric.addEventDuration(true, fortyMillisAsNanos);
+    Timer.Stats stats3 = collectTimer(bucket, CollectionMode.CUMULATIVE);
+    assertEquals(2, stats3.count());
+    assertEquals(90_000, stats3.total());
+    assertEquals(40_000, stats3.max());
 
     Timer.Stats delta = collectTimer(bucket);
-    assertEquals(1, delta.count());
+    assertEquals(2, delta.count());
+    assertEquals(90_000, delta.total());
+    assertEquals(0, delta.max());
     assertThat(collect(bucket)).isEmpty();
   }
 

--- a/metrics/src/test/java/io/avaje/metrics/core/DBucketTimerTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/DBucketTimerTest.java
@@ -1,5 +1,6 @@
 package io.avaje.metrics.core;
 
+import io.avaje.metrics.CollectionMode;
 import io.avaje.metrics.Metric;
 import io.avaje.metrics.NamingMatch;
 import io.avaje.metrics.Timer;
@@ -69,8 +70,35 @@ class DBucketTimerTest {
     assertThat(collect(buckets[2])).isEmpty();
   }
 
+  @Test
+  void collectTimer_cumulative() {
+    DBucketTimer bucketTimedMetric = create();
+
+    long fiftyMillisAsNanos = TimeUnit.MILLISECONDS.toNanos(50);
+    bucketTimedMetric.addEventDuration(true, fiftyMillisAsNanos);
+
+    Timer bucket = bucketTimedMetric.buckets[0];
+    Timer.Stats stats = collectTimer(bucket, CollectionMode.CUMULATIVE);
+    assertEquals(1, stats.count());
+    assertEquals(50_000, stats.total());
+
+    Timer.Stats stats2 = collectTimer(bucket, CollectionMode.CUMULATIVE);
+    assertEquals(1, stats2.count());
+    assertEquals(50_000, stats2.total());
+
+    Timer.Stats delta = collectTimer(bucket);
+    assertEquals(1, delta.count());
+    assertThat(collect(bucket)).isEmpty();
+  }
+
   private Timer.Stats collectTimer(Timer timer) {
     DStatsCollector collector = new DStatsCollector(NamingMatch.INSTANCE);
+    timer.collect(collector);
+    return (Timer.Stats) collector.list().get(0);
+  }
+
+  private Timer.Stats collectTimer(Timer timer, CollectionMode mode) {
+    DStatsCollector collector = new DStatsCollector(NamingMatch.INSTANCE, mode);
     timer.collect(collector);
     return (Timer.Stats) collector.list().get(0);
   }

--- a/metrics/src/test/java/io/avaje/metrics/core/MeterTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/MeterTest.java
@@ -49,11 +49,20 @@ class MeterTest {
     Meter.Stats statistics2 = (Meter.Stats) collect(metric, CollectionMode.CUMULATIVE).get(0);
     assertEquals(3, statistics2.count());
     assertEquals(4500, statistics2.total());
-    assertEquals(2000, statistics2.max());
+    assertEquals(0, statistics2.max());
     assertEquals(1500, statistics2.mean());
 
+    metric.addEvent(750);
+    Meter.Stats statistics3 = (Meter.Stats) collect(metric, CollectionMode.CUMULATIVE).get(0);
+    assertEquals(4, statistics3.count());
+    assertEquals(5250, statistics3.total());
+    assertEquals(750, statistics3.max());
+    assertEquals(1312, statistics3.mean());
+
     Meter.Stats delta = (Meter.Stats) collect(metric).get(0);
-    assertEquals(3, delta.count());
+    assertEquals(4, delta.count());
+    assertEquals(5250, delta.total());
+    assertEquals(0, delta.max());
     assertEquals(0, metric.count());
     assertThat(collect(metric)).isEmpty();
   }

--- a/metrics/src/test/java/io/avaje/metrics/core/MeterTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/MeterTest.java
@@ -33,8 +33,39 @@ class MeterTest {
     assertThat(collect(metric)).isEmpty();
   }
 
+  @Test
+  void collectCumulative() {
+    Meter metric = new DMeter(Metric.ID.of("org.test.mycounter.cumulative"));
+    metric.addEvent(1000);
+    metric.addEvent(2000);
+    metric.addEvent(1500);
+
+    Meter.Stats statistics = (Meter.Stats) collect(metric, CollectionMode.CUMULATIVE).get(0);
+    assertEquals(3, statistics.count());
+    assertEquals(4500, statistics.total());
+    assertEquals(2000, statistics.max());
+    assertEquals(1500, statistics.mean());
+
+    Meter.Stats statistics2 = (Meter.Stats) collect(metric, CollectionMode.CUMULATIVE).get(0);
+    assertEquals(3, statistics2.count());
+    assertEquals(4500, statistics2.total());
+    assertEquals(2000, statistics2.max());
+    assertEquals(1500, statistics2.mean());
+
+    Meter.Stats delta = (Meter.Stats) collect(metric).get(0);
+    assertEquals(3, delta.count());
+    assertEquals(0, metric.count());
+    assertThat(collect(metric)).isEmpty();
+  }
+
   private List<Metric.Statistics> collect(Metric metric) {
     DStatsCollector collector = new DStatsCollector(NamingMatch.INSTANCE);
+    metric.collect(collector);
+    return collector.list();
+  }
+
+  private List<Metric.Statistics> collect(Metric metric, CollectionMode mode) {
+    DStatsCollector collector = new DStatsCollector(NamingMatch.INSTANCE, mode);
     metric.collect(collector);
     return collector.list();
   }

--- a/metrics/src/test/java/io/avaje/metrics/core/TimerTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/TimerTest.java
@@ -158,6 +158,37 @@ class TimerTest {
     assertThat(stat0.max()).isGreaterThan(0);
   }
 
+  @Test
+  void collectMetrics_cumulative() {
+    MetricRegistry registry = Metrics.createRegistry();
+    Timer metric = registry.timer("test.timer.cumulative");
+
+    long start = System.nanoTime();
+    metric.add(start);
+    metric.addErr(start);
+
+    List<Metric.Statistics> stats = registry.collectMetrics(CollectionMode.CUMULATIVE);
+    assertThat(stats).hasSize(2);
+
+    Timer.Stats success = (Timer.Stats) stats.get(0);
+    Timer.Stats error = (Timer.Stats) stats.get(1);
+    assertEquals("test.timer.cumulative", success.name());
+    assertEquals(1, success.count());
+    assertEquals("test.timer.cumulative.error", error.name());
+    assertEquals(1, error.count());
+
+    List<Metric.Statistics> stats2 = registry.collectMetrics(CollectionMode.CUMULATIVE);
+    assertThat(stats2).hasSize(2);
+    assertEquals(1, ((Timer.Stats) stats2.get(0)).count());
+    assertEquals(1, ((Timer.Stats) stats2.get(1)).count());
+
+    List<Metric.Statistics> stats3 = registry.collectMetrics();
+    assertThat(stats3).hasSize(2);
+    assertEquals(1, ((Timer.Stats) stats3.get(0)).count());
+    assertEquals(1, ((Timer.Stats) stats3.get(1)).count());
+    assertThat(registry.collectMetrics()).isEmpty();
+  }
+
 //
 //  @Test
 //  public void addEventSince() {

--- a/metrics/src/test/java/io/avaje/metrics/core/TimerTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/TimerTest.java
@@ -4,6 +4,7 @@ import io.avaje.metrics.*;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -163,9 +164,8 @@ class TimerTest {
     MetricRegistry registry = Metrics.createRegistry();
     Timer metric = registry.timer("test.timer.cumulative");
 
-    long start = System.nanoTime();
-    metric.add(start);
-    metric.addErr(start);
+    metric.addEventDuration(true, TimeUnit.MILLISECONDS.toNanos(5));
+    metric.addEventDuration(false, TimeUnit.MILLISECONDS.toNanos(2));
 
     List<Metric.Statistics> stats = registry.collectMetrics(CollectionMode.CUMULATIVE);
     assertThat(stats).hasSize(2);
@@ -174,18 +174,41 @@ class TimerTest {
     Timer.Stats error = (Timer.Stats) stats.get(1);
     assertEquals("test.timer.cumulative", success.name());
     assertEquals(1, success.count());
+    assertEquals(5_000, success.total());
+    assertEquals(5_000, success.max());
     assertEquals("test.timer.cumulative.error", error.name());
     assertEquals(1, error.count());
+    assertEquals(2_000, error.total());
+    assertEquals(2_000, error.max());
 
     List<Metric.Statistics> stats2 = registry.collectMetrics(CollectionMode.CUMULATIVE);
     assertThat(stats2).hasSize(2);
     assertEquals(1, ((Timer.Stats) stats2.get(0)).count());
+    assertEquals(5_000, ((Timer.Stats) stats2.get(0)).total());
+    assertEquals(0, ((Timer.Stats) stats2.get(0)).max());
     assertEquals(1, ((Timer.Stats) stats2.get(1)).count());
+    assertEquals(2_000, ((Timer.Stats) stats2.get(1)).total());
+    assertEquals(0, ((Timer.Stats) stats2.get(1)).max());
 
-    List<Metric.Statistics> stats3 = registry.collectMetrics();
+    metric.addEventDuration(true, TimeUnit.MILLISECONDS.toNanos(3));
+    metric.addEventDuration(false, TimeUnit.MILLISECONDS.toNanos(7));
+    List<Metric.Statistics> stats3 = registry.collectMetrics(CollectionMode.CUMULATIVE);
     assertThat(stats3).hasSize(2);
-    assertEquals(1, ((Timer.Stats) stats3.get(0)).count());
-    assertEquals(1, ((Timer.Stats) stats3.get(1)).count());
+    assertEquals(2, ((Timer.Stats) stats3.get(0)).count());
+    assertEquals(8_000, ((Timer.Stats) stats3.get(0)).total());
+    assertEquals(3_000, ((Timer.Stats) stats3.get(0)).max());
+    assertEquals(2, ((Timer.Stats) stats3.get(1)).count());
+    assertEquals(9_000, ((Timer.Stats) stats3.get(1)).total());
+    assertEquals(7_000, ((Timer.Stats) stats3.get(1)).max());
+
+    List<Metric.Statistics> stats4 = registry.collectMetrics();
+    assertThat(stats4).hasSize(2);
+    assertEquals(2, ((Timer.Stats) stats4.get(0)).count());
+    assertEquals(8_000, ((Timer.Stats) stats4.get(0)).total());
+    assertEquals(0, ((Timer.Stats) stats4.get(0)).max());
+    assertEquals(2, ((Timer.Stats) stats4.get(1)).count());
+    assertEquals(9_000, ((Timer.Stats) stats4.get(1)).total());
+    assertEquals(0, ((Timer.Stats) stats4.get(1)).max());
     assertThat(registry.collectMetrics()).isEmpty();
   }
 

--- a/metrics/src/test/java/io/avaje/metrics/core/ValueCounterTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/ValueCounterTest.java
@@ -10,7 +10,7 @@ class ValueCounterTest {
   @Test
   void testGetStatisticsWithNoReset() {
     ValueCounter counter = new ValueCounter(Metric.ID.of("junk"));
-    assertEquals(Long.MIN_VALUE, counter.max());
+    assertEquals(0, counter.max());
 
     counter.add(100);
 
@@ -31,7 +31,7 @@ class ValueCounterTest {
 
     assertEquals(0, counter.count());
     assertEquals(0, counter.total());
-    assertEquals(Long.MIN_VALUE, counter.max());
+    assertEquals(0, counter.max());
 
     counter.add(100);
     assertEquals(1, counter.count());
@@ -56,6 +56,6 @@ class ValueCounterTest {
     counter.reset();
     assertEquals(0, counter.count());
     assertEquals(0, counter.total());
-    assertEquals(Long.MIN_VALUE, counter.max());
+    assertEquals(0, counter.max());
   }
 }


### PR DESCRIPTION
Traditionally avaje-metrics has been DELTA only, and this allows for a CUMULATIVE mode where effectively the metrics are not reset on collection.