### PR TITLE
Add back the overloaded methods taking Tags for Timer, Counter, Meter

### DIFF
--- a/metrics-ebean/pom.xml
+++ b/metrics-ebean/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.9-RC8</version>
+    <version>9.9</version>
   </parent>
 
   <artifactId>avaje-metrics-ebean</artifactId>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.9-RC8</version>
+      <version>9.9</version>
       <scope>provided</scope>
     </dependency>
 

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.9-RC8</version>
+    <version>9.9</version>
   </parent>
 
   <artifactId>avaje-metrics-graphite</artifactId>
   <name>avaje-metrics-graphite</name>
-  <version>9.9-RC8</version>
+  <version>9.9</version>
 
   <properties>
     <surefire.useModulePath>false</surefire.useModulePath>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.9-RC8</version>
+      <version>9.9</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-producer/pom.xml
+++ b/metrics-otel-producer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.9-RC8</version>
+    <version>9.9</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-producer</artifactId>
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.9-RC8</version>
+      <version>9.9</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-reporter/pom.xml
+++ b/metrics-otel-reporter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.9-RC8</version>
+    <version>9.9</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-reporter</artifactId>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.9-RC8</version>
+      <version>9.9</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-trace/pom.xml
+++ b/metrics-otel-trace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.9-RC8</version>
+    <version>9.9</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-trace</artifactId>
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.9-RC8</version>
+      <version>9.9</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel/pom.xml
+++ b/metrics-otel/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.9-RC8</version>
+    <version>9.9</version>
   </parent>
 
   <artifactId>avaje-metrics-otel</artifactId>
@@ -20,19 +20,19 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.9-RC8</version>
+      <version>9.9</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics-otel-producer</artifactId>
-      <version>9.9-RC8</version>
+      <version>9.9</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics-otel-trace</artifactId>
-      <version>9.9-RC8</version>
+      <version>9.9</version>
     </dependency>
 
     <dependency>

--- a/metrics-prometheus/pom.xml
+++ b/metrics-prometheus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.9-RC8</version>
+    <version>9.9</version>
   </parent>
 
   <artifactId>avaje-metrics-prometheus</artifactId>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.9-RC8</version>
+      <version>9.9</version>
     </dependency>
 
     <dependency>

--- a/metrics-statsd/pom.xml
+++ b/metrics-statsd/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.9-RC8</version>
+    <version>9.9</version>
   </parent>
 
   <artifactId>avaje-metrics-statsd</artifactId>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.9-RC8</version>
+      <version>9.9</version>
     </dependency>
 
     <dependency>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.9-RC8</version>
+    <version>9.9</version>
   </parent>
 
   <artifactId>avaje-metrics</artifactId>

--- a/metrics/src/main/java/io/avaje/metrics/MetricRegistry.java
+++ b/metrics/src/main/java/io/avaje/metrics/MetricRegistry.java
@@ -16,6 +16,11 @@ public interface MetricRegistry extends JvmMetrics {
   Counter counter(String name);
 
   /**
+   * Return the Counter using the metric name and tags.
+   */
+  Counter counter(String name, Tags tags);
+
+  /**
    * Return a builder used to configure and register a counter.
    */
   CounterBuilder counterBuilder(String name);
@@ -24,6 +29,11 @@ public interface MetricRegistry extends JvmMetrics {
    * Return the Meter using the metric name.
    */
   Meter meter(String name);
+
+  /**
+   * Return the Meter using the metric name and tags.
+   */
+  Meter meter(String name, Tags tags);
 
   /**
    * Return a builder used to configure and register a meter.
@@ -49,6 +59,11 @@ public interface MetricRegistry extends JvmMetrics {
    * Return the timer using the metric name.
    */
   Timer timer(String name);
+
+  /**
+   * Return the timer using the metric name and tags.
+   */
+  Timer timer(String name, Tags tags);
 
   /**
    * Return a builder used to configure and register a timer.

--- a/metrics/src/main/java/io/avaje/metrics/Metrics.java
+++ b/metrics/src/main/java/io/avaje/metrics/Metrics.java
@@ -100,6 +100,13 @@ public class Metrics {
   }
 
   /**
+   * Return a Timer given the name and tags using the default registry.
+   */
+  public static Timer timer(String name, Tags tags) {
+    return defaultRegistry.timer(name, tags);
+  }
+
+  /**
    * Return a builder used to configure and register a timer with the default registry.
    */
   public static TimerBuilder timerBuilder(String name) {
@@ -121,6 +128,13 @@ public class Metrics {
   }
 
   /**
+   * Return a Counter given the name and tags using the default registry.
+   */
+  public static Counter counter(String name, Tags tags) {
+    return defaultRegistry.counter(name, tags);
+  }
+
+  /**
    * Return a builder used to configure and register a counter with the default registry.
    */
   public static CounterBuilder counterBuilder(String name) {
@@ -139,6 +153,13 @@ public class Metrics {
    */
   public static Meter meter(String name) {
     return defaultRegistry.meter(name);
+  }
+
+  /**
+   * Return a Meter given the name and tags using the default registry.
+   */
+  public static Meter meter(String name, Tags tags) {
+    return defaultRegistry.meter(name, tags);
   }
 
   /**

--- a/metrics/src/main/java/io/avaje/metrics/core/DefaultMetricProvider.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DefaultMetricProvider.java
@@ -224,6 +224,12 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
   }
 
   @Override
+  public Timer timer(String name, Tags tags) {
+    Timer timer = get(name, tags, Timer.class);
+    return timer != null ? timer : timer(name, tags, null);
+  }
+
+  @Override
   public TimerBuilder timerBuilder(String name) {
     return new DTimerBuilder(name);
   }
@@ -234,6 +240,12 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
   }
 
   @Override
+  public Counter counter(String name, Tags tags) {
+    Counter counter = get(name, tags, Counter.class);
+    return counter != null ? counter : counter(name, tags, COUNT_UNIT);
+  }
+
+  @Override
   public CounterBuilder counterBuilder(String name) {
     return new DCounterBuilder(name);
   }
@@ -241,6 +253,12 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
   @Override
   public Meter meter(String name) {
     return meterBuilder(name).build();
+  }
+
+  @Override
+  public Meter meter(String name, Tags tags) {
+    Meter meter = get(name, tags, Meter.class);
+    return meter != null ? meter : meter(name, tags, DEFAULT_UNIT);
   }
 
   @Override
@@ -375,6 +393,22 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
       throw new IllegalStateException(
         "Metric " + id.name() + " already registered with unit '" + existing.unit() + "' not '" + normalizedUnit + "'");
     }
+  }
+
+  @Nullable
+  private <T extends Metric> T get(String name, Tags tags, Class<T> type) {
+    Metric.ID id = Metric.ID.of(requireNonNull(name), requireNonNull(tags));
+    Metric metric = metricsCache.get(id);
+    return metric != null ? validateType(id, metric, type) : null;
+  }
+
+  private static <T extends Metric> T validateType(Metric.ID id, Metric metric, Class<T> type) {
+    if (!type.isInstance(metric)) {
+      throw new IllegalStateException(
+        "Metric " + id.name() + " already registered as " + metric.getClass().getSimpleName()
+          + " not " + type.getSimpleName());
+    }
+    return type.cast(metric);
   }
 
   private static <T extends Metric> T validateMetric(Metric.ID id, Metric metric, Class<T> type, String unit) {

--- a/metrics/src/test/java/io/avaje/metrics/MetricsTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/MetricsTest.java
@@ -60,4 +60,20 @@ class MetricsTest {
       .extracting(Metric.ID::tags)
       .isEqualTo(Tags.of("env:test"));
   }
+
+  @Test
+  void metricOverloadsWithTags_useDefaultRegistry() {
+    var tags = Tags.of("scope:facade", "env:test");
+
+    var counter = Metrics.counter("app.metrics.facade.counter", tags);
+    var meter = Metrics.meter("app.metrics.facade.meter", tags);
+    var timer = Metrics.timer("app.metrics.facade.timer", tags);
+
+    assertThat(Metrics.counter("app.metrics.facade.counter", tags)).isSameAs(counter);
+    assertThat(Metrics.meter("app.metrics.facade.meter", tags)).isSameAs(meter);
+    assertThat(Metrics.timer("app.metrics.facade.timer", tags)).isSameAs(timer);
+    assertThat(counter.id().tags()).isEqualTo(tags);
+    assertThat(meter.id().tags()).isEqualTo(tags);
+    assertThat(timer.id().tags()).isEqualTo(tags);
+  }
 }

--- a/metrics/src/test/java/io/avaje/metrics/core/CounterMetricTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/CounterMetricTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CounterMetricTest {
@@ -70,6 +71,58 @@ class CounterMetricTest {
     assertThat(counter0.count()).isEqualTo(0);
     assertThat(counter1.count()).isEqualTo(0);
     assertThat(counter2.count()).isEqualTo(0);
+  }
+
+  @Test
+  void withTags() {
+    var registry = Metrics.createRegistry();
+    var tags = Tags.of("scope:counter", "env:test");
+
+    var counter0 = registry.counter("api.fastPath.counter", tags);
+    var counter1 = registry.counter("api.fastPath.counter", tags);
+    var counter2 = registry.counter("api.fastPath.counter", Tags.of("scope:counter", "env:other"));
+
+    assertThat(counter0).isSameAs(counter1);
+    assertThat(counter0).isNotSameAs(counter2);
+    assertThat(counter0.id().tags()).isEqualTo(tags);
+    assertThat(counter2.id().tags()).isEqualTo(Tags.of("scope:counter", "env:other"));
+  }
+
+  @Test
+  void withTags_whenBuilderCreated_expectCachedMetric() {
+    var registry = Metrics.createRegistry();
+    var tags = Tags.of("scope:counter", "source:builder");
+
+    var counter = registry.counterBuilder("api.fastPath.counter.builder")
+      .tags(tags)
+      .unit("row")
+      .build();
+
+    assertThat(registry.counter("api.fastPath.counter.builder", tags)).isSameAs(counter);
+  }
+
+  @Test
+  void withTags_whenDifferentMetricType_expectIllegalStateException() {
+    var registry = Metrics.createRegistry();
+    var tags = Tags.of("scope:counter", "kind:conflict");
+
+    registry.meter("api.fastPath.counter.conflict", tags);
+
+    assertThatThrownBy(() -> registry.counter("api.fastPath.counter.conflict", tags))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("already registered as")
+      .hasMessageContaining("not Counter");
+  }
+
+  @Test
+  void withTags_whenNullNameOrTags_expectNullPointerException() {
+    var registry = Metrics.createRegistry();
+    var tags = Tags.of("scope:counter", "kind:null");
+
+    assertThatThrownBy(() -> registry.counter(null, tags))
+      .isInstanceOf(NullPointerException.class);
+    assertThatThrownBy(() -> registry.counter("api.fastPath.counter.nullTags", null))
+      .isInstanceOf(NullPointerException.class);
   }
 
   @Test

--- a/metrics/src/test/java/io/avaje/metrics/core/MeterTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/MeterTest.java
@@ -34,6 +34,34 @@ class MeterTest {
   }
 
   @Test
+  void withTags() {
+    var registry = Metrics.createRegistry();
+    var tags = Tags.of("scope:meter", "env:test");
+
+    var meter0 = registry.meter("api.fastPath.meter", tags);
+    var meter1 = registry.meter("api.fastPath.meter", tags);
+    var meter2 = registry.meter("api.fastPath.meter", Tags.of("scope:meter", "env:other"));
+
+    assertThat(meter0).isSameAs(meter1);
+    assertThat(meter0).isNotSameAs(meter2);
+    assertThat(meter0.id().tags()).isEqualTo(tags);
+    assertThat(meter2.id().tags()).isEqualTo(Tags.of("scope:meter", "env:other"));
+  }
+
+  @Test
+  void withTags_whenBuilderCreated_expectCachedMetric() {
+    var registry = Metrics.createRegistry();
+    var tags = Tags.of("scope:meter", "source:builder");
+
+    var meter = registry.meterBuilder("api.fastPath.meter.builder")
+      .tags(tags)
+      .unit("By")
+      .build();
+
+    assertThat(registry.meter("api.fastPath.meter.builder", tags)).isSameAs(meter);
+  }
+
+  @Test
   void collectCumulative() {
     Meter metric = new DMeter(Metric.ID.of("org.test.mycounter.cumulative"), "");
     metric.addEvent(1000);

--- a/metrics/src/test/java/io/avaje/metrics/core/TimerTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/TimerTest.java
@@ -66,6 +66,33 @@ class TimerTest {
     assertEquals(2, stat1.count());
   }
 
+  @Test
+  void withTags() {
+    var registry = Metrics.createRegistry();
+    var tags = Tags.of("scope:timer", "env:test");
+
+    var timer0 = registry.timer("api.fastPath.timer", tags);
+    var timer1 = registry.timer("api.fastPath.timer", tags);
+    var timer2 = registry.timer("api.fastPath.timer", Tags.of("scope:timer", "env:other"));
+
+    assertThat(timer0).isSameAs(timer1);
+    assertThat(timer0).isNotSameAs(timer2);
+    assertThat(timer0.id().tags()).isEqualTo(tags);
+    assertThat(timer2.id().tags()).isEqualTo(Tags.of("scope:timer", "env:other"));
+  }
+
+  @Test
+  void withTags_whenBuilderCreated_expectCachedMetric() {
+    var registry = Metrics.createRegistry();
+    var tags = Tags.of("scope:timer", "source:builder");
+
+    var timer = registry.timerBuilder("api.fastPath.timer.builder")
+      .tags(tags)
+      .build();
+
+    assertThat(registry.timer("api.fastPath.timer.builder", tags)).isSameAs(timer);
+  }
+
   private void resetStatistics() {
     Metrics.collectMetrics();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>io.avaje</groupId>
   <artifactId>avaje-metrics-parent</artifactId>
   <name>avaje-metrics-parent</name>
-  <version>9.9-RC8</version>
+  <version>9.9</version>
   <packaging>pom</packaging>
 
   <url>https://avaje-metrics.github.io</url>
@@ -23,7 +23,7 @@
 
   <properties>
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
-    <project.build.outputTimestamp>2026-05-22T03:58:21Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-05-25T22:30:52Z</project.build.outputTimestamp>
   </properties>
 
   <modules>


### PR DESCRIPTION
As these are actually used a decent amount with Tags so good to have
these options and them being a faster execution path (skip unit validation).