### PR TITLE
Modify Graphite reporter to support Label Tags

### DIFF
--- a/metrics-graphite/README.md
+++ b/metrics-graphite/README.md
@@ -44,6 +44,16 @@ reporter.report();
 - `database(...)` — include Ebean database metrics directly
 - `excludeDefaultRegistry()` — report only explicitly added registries/suppliers
 
+## Label tags
+
+Graphite metric paths do not carry tags. When a metric has a `label:<value>` tag,
+the reporter appends the label value to the Graphite metric path. For example,
+`web.api` with `label:MyController.myMethod` is reported as
+`web.api.MyController.myMethod.count`, `web.api.MyController.myMethod.total`,
+and related timer series. The `app.component` base name is reported using the
+legacy `app.<label>` path, such as `app.MyClass.myMethod.count`. Non-label tags
+are ignored by this reporter.
+
 ## Manual sending
 
 If you need low-level manual sending rather than reporter composition, use

--- a/metrics-graphite/src/main/java/io/avaje/metrics/graphite/DGraphiteSender.java
+++ b/metrics-graphite/src/main/java/io/avaje/metrics/graphite/DGraphiteSender.java
@@ -21,6 +21,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 final class DGraphiteSender implements GraphiteSender {
 
   private static final System.Logger log = AppLog.getLogger(GraphiteReporter.class);
+  private static final String LABEL_PREFIX = "label:";
+  private static final String APP_COMPONENT_NAME = "app.component";
+  private static final String APP_PREFIX = "app.";
 
   /**
    * Minimally necessary pickle opcodes.
@@ -100,10 +103,11 @@ final class DGraphiteSender implements GraphiteSender {
 
     private void sendValues(Meter.Stats stats) {
       try {
-        send(String.valueOf(stats.count()), epochSecs, stats.name(), ".count");
-        send(String.valueOf(stats.total()), epochSecs, stats.name(), ".total");
-        send(String.valueOf(stats.mean()), epochSecs, stats.name(), ".mean");
-        send(String.valueOf(stats.max()), epochSecs, stats.name(), ".max");
+        var name = graphiteName(stats.id());
+        send(String.valueOf(stats.count()), epochSecs, name, ".count");
+        send(String.valueOf(stats.total()), epochSecs, name, ".total");
+        send(String.valueOf(stats.mean()), epochSecs, name, ".mean");
+        send(String.valueOf(stats.max()), epochSecs, name, ".max");
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
@@ -112,7 +116,7 @@ final class DGraphiteSender implements GraphiteSender {
     @Override
     public void visit(Counter.Stats counter) {
       try {
-        send(String.valueOf(counter.count()), epochSecs, counter.name());
+        send(String.valueOf(counter.count()), epochSecs, graphiteName(counter.id()));
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
@@ -121,7 +125,7 @@ final class DGraphiteSender implements GraphiteSender {
     @Override
     public void visit(GaugeDouble.Stats gauge) {
       try {
-        send(String.valueOf(gauge.value()), epochSecs, gauge.name());
+        send(String.valueOf(gauge.value()), epochSecs, graphiteName(gauge.id()));
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
@@ -130,11 +134,25 @@ final class DGraphiteSender implements GraphiteSender {
     @Override
     public void visit(GaugeLong.Stats gauge) {
       try {
-        send(String.valueOf(gauge.value()), epochSecs, gauge.name());
+        send(String.valueOf(gauge.value()), epochSecs, graphiteName(gauge.id()));
       } catch (IOException e) {
         throw new UncheckedIOException(e);
       }
     }
+  }
+
+  private static String graphiteName(Metric.ID id) {
+    var name = id.name();
+    for (String tag : id.tags().array()) {
+      if (tag != null && tag.startsWith(LABEL_PREFIX) && tag.length() > LABEL_PREFIX.length()) {
+        var label = tag.substring(LABEL_PREFIX.length());
+        if (APP_COMPONENT_NAME.equals(name)) {
+          return APP_PREFIX + label;
+        }
+        return name + "." + label;
+      }
+    }
+    return name;
   }
 
   @Override

--- a/metrics-graphite/src/main/java/io/avaje/metrics/graphite/DGraphiteSender.java
+++ b/metrics-graphite/src/main/java/io/avaje/metrics/graphite/DGraphiteSender.java
@@ -10,6 +10,7 @@ import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.regex.Pattern;
 
 import static java.lang.System.Logger.Level.INFO;
@@ -42,6 +43,7 @@ final class DGraphiteSender implements GraphiteSender {
 
   private final int batchSize;
   private final List<MetricTuple> metrics = new ArrayList<>();
+  private final ConcurrentHashMap<Metric.ID, String> graphiteNames = new ConcurrentHashMap<>();
   private final InetSocketAddress address;
   private final SocketFactory socketFactory;
   private final String prefix;
@@ -141,7 +143,11 @@ final class DGraphiteSender implements GraphiteSender {
     }
   }
 
-  private static String graphiteName(Metric.ID id) {
+  private String graphiteName(Metric.ID id) {
+    return graphiteNames.computeIfAbsent(id, DGraphiteSender::createGraphiteName);
+  }
+
+  private static String createGraphiteName(Metric.ID id) {
     var name = id.name();
     for (String tag : id.tags().array()) {
       if (tag != null && tag.startsWith(LABEL_PREFIX) && tag.length() > LABEL_PREFIX.length()) {

--- a/metrics-graphite/src/test/java/io/avaje/metrics/graphite/DGraphiteSenderTest.java
+++ b/metrics-graphite/src/test/java/io/avaje/metrics/graphite/DGraphiteSenderTest.java
@@ -1,0 +1,183 @@
+package io.avaje.metrics.graphite;
+
+import io.avaje.metrics.Metric;
+import io.avaje.metrics.Tags;
+import io.avaje.metrics.stats.CounterStats;
+import io.avaje.metrics.stats.GaugeDoubleStats;
+import io.avaje.metrics.stats.GaugeLongStats;
+import io.avaje.metrics.stats.TimerStats;
+import org.junit.jupiter.api.Test;
+
+import javax.net.SocketFactory;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DGraphiteSenderTest {
+
+  @Test
+  void sendTimer_withLabelTag_flattensLabelIntoMetricName() throws IOException {
+    var socketFactory = new RecordingSocketFactory();
+    var sender = sender(socketFactory);
+    sender.connect();
+
+    sender.send(List.of(new TimerStats(
+      Metric.ID.of("web.api", Tags.of("env:prod", "label:MyController.myMethod")),
+      2,
+      40,
+      30)));
+    sender.flush();
+
+    var payload = payload(socketFactory);
+    assertThat(payload)
+      .contains("'web.api.MyController.myMethod.count'")
+      .contains("'web.api.MyController.myMethod.total'")
+      .contains("'web.api.MyController.myMethod.mean'")
+      .contains("'web.api.MyController.myMethod.max'")
+      .doesNotContain("'web.api.count'");
+  }
+
+  @Test
+  void sendTimer_withAppComponentLabelTag_usesLegacyAppMetricName() throws IOException {
+    var socketFactory = new RecordingSocketFactory();
+    var sender = sender(socketFactory);
+    sender.connect();
+
+    sender.send(List.of(new TimerStats(
+      Metric.ID.of("app.component", Tags.of("label:MyClass.myMethod")),
+      2,
+      40,
+      30)));
+    sender.flush();
+
+    var payload = payload(socketFactory);
+    assertThat(payload)
+      .contains("'app.MyClass.myMethod.count'")
+      .contains("'app.MyClass.myMethod.total'")
+      .contains("'app.MyClass.myMethod.mean'")
+      .contains("'app.MyClass.myMethod.max'")
+      .doesNotContain("'app.component.MyClass.myMethod.count'");
+  }
+
+  @Test
+  void sendTimer_withoutLabelTag_keepsMetricName() throws IOException {
+    var socketFactory = new RecordingSocketFactory();
+    var sender = sender(socketFactory);
+    sender.connect();
+
+    sender.send(List.of(new TimerStats(Metric.ID.of("web.api", Tags.of("env:prod")), 2, 40, 30)));
+    sender.flush();
+
+    var payload = payload(socketFactory);
+    assertThat(payload)
+      .contains("'web.api.count'")
+      .contains("'web.api.total'")
+      .contains("'web.api.mean'")
+      .contains("'web.api.max'")
+      .doesNotContain("env:prod");
+  }
+
+  @Test
+  void sendCounterAndGauges_withLabelTag_flattenLabelIntoMetricName() throws IOException {
+    var socketFactory = new RecordingSocketFactory();
+    var sender = sender(socketFactory);
+    sender.connect();
+
+    sender.send(List.of(
+      new CounterStats(Metric.ID.of("custom.component", Tags.of("label:Service.count")), 42),
+      new GaugeDoubleStats(Metric.ID.of("custom.component", Tags.of("label:Service.doubleGauge")), 12.5),
+      new GaugeLongStats(Metric.ID.of("custom.component", Tags.of("label:Service.longGauge")), 99)));
+    sender.flush();
+
+    var payload = payload(socketFactory);
+    assertThat(payload)
+      .contains("'custom.component.Service.count'")
+      .contains("'custom.component.Service.doubleGauge'")
+      .contains("'custom.component.Service.longGauge'");
+  }
+
+  private DGraphiteSender sender(RecordingSocketFactory socketFactory) {
+    var address = new InetSocketAddress(InetAddress.getLoopbackAddress(), 2003);
+    return new DGraphiteSender(address, socketFactory, 500, null, 0);
+  }
+
+  private String payload(RecordingSocketFactory socketFactory) {
+    var bytes = socketFactory.bytes();
+    var payloadLength = ByteBuffer.wrap(bytes, 0, 4).getInt();
+    assertThat(payloadLength).isEqualTo(bytes.length - 4);
+    return new String(bytes, 4, payloadLength, UTF_8);
+  }
+
+  private static final class RecordingSocketFactory extends SocketFactory {
+
+    private final RecordingSocket socket = new RecordingSocket();
+
+    @Override
+    public Socket createSocket() {
+      return socket;
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) {
+      return socket;
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) {
+      return socket;
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) {
+      return socket;
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) {
+      return socket;
+    }
+
+    private byte[] bytes() {
+      return socket.bytes();
+    }
+  }
+
+  private static final class RecordingSocket extends Socket {
+
+    private final ByteArrayOutputStream output = new ByteArrayOutputStream();
+    private boolean closed;
+
+    @Override
+    public OutputStream getOutputStream() {
+      return output;
+    }
+
+    @Override
+    public boolean isConnected() {
+      return true;
+    }
+
+    @Override
+    public boolean isClosed() {
+      return closed;
+    }
+
+    @Override
+    public synchronized void close() throws IOException {
+      closed = true;
+      super.close();
+    }
+
+    private byte[] bytes() {
+      return output.toByteArray();
+    }
+  }
+}


### PR DESCRIPTION
Detects when Label Tags are used and flattens that back into the metric name and is compatible with prior names.

This means that in the future we can change the default naming over to Label-Tag and still be compatible with existing Graphite and StatsD.