### PR TITLE
[Open telemetry] Add ROOT spans via `@Timed(span=SpanMode.ROOT)`

### DIFF
--- a/docs/guides/add-method-timing.md
+++ b/docs/guides/add-method-timing.md
@@ -18,7 +18,8 @@ There are three main timing styles:
 |---|---|
 | `@Timed` | declarative timing via build-time enhancement |
 | `Timer.time(...)` or `Timer.startEvent()` | explicit programmatic timing in code |
-| `Metrics.timerBuilder(...).buildTraced()` | timing plus spans when trace support is present |
+| `Metrics.timerBuilder(...).buildTraced()` | timing plus child spans when trace support is present |
+| `Metrics.timerBuilder(...).buildRootTraced()` | timing plus root-if-needed spans when trace support is present |
 
 If you do **not** want enhancement, programmatic timers are the safest and most explicit
 path. If you want `@Timed`, configure build-time enhancement first.
@@ -88,7 +89,7 @@ Add `avaje-metrics-otel-trace` when the project already has OpenTelemetry config
 </dependency>
 ```
 
-Then build a traced timer:
+Then build a child traced timer:
 
 ```java
 var tracedTimer = Metrics.timerBuilder("app.service.run")
@@ -98,8 +99,18 @@ var tracedTimer = Metrics.timerBuilder("app.service.run")
 tracedTimer.time(service::run);
 ```
 
-`buildTraced()` creates spans when trace support is available and the application has a
-global `OpenTelemetry` instance.
+`buildTraced()` creates child spans when trace support is available, the application has a
+global `OpenTelemetry` instance, and there is a current recording span.
+
+Use `buildRootTraced()` for a top-level boundary that should start a root span when no
+recording span is current:
+
+```java
+var rootTimer = Metrics.timerBuilder("app.lambda.handle")
+  .buildRootTraced();
+
+rootTimer.time(handler::handleRequest);
+```
 
 ---
 
@@ -148,7 +159,7 @@ static timer setup, so use stable low-cardinality values rather than request-spe
 You can also enable spans for enhanced methods:
 
 ```java
-@Timed(span = Timed.SpanMode.ON)
+@Timed(span = Timed.SpanMode.CHILD)
 class BillingService {
   void syncInvoices() {
   }
@@ -161,7 +172,8 @@ Important behavior:
 - `@NotTimed` excludes specific methods
 - method-level `@Timed` is useful for overrides or private methods
 - `@Timed(tags = {...})` adds custom timer tags using `key:value` values
-- `@Timed(span = Timed.SpanMode.ON)` requires trace support such as `avaje-metrics-otel-trace`
+- `@Timed(span = Timed.SpanMode.CHILD)` requires trace support such as `avaje-metrics-otel-trace`
+- `@Timed(span = Timed.SpanMode.ROOT)` starts a root span when no recording span is current
 
 ---
 
@@ -180,6 +192,7 @@ name. Success and error timing are tracked separately.
 ## Notes
 
 - Prefer programmatic timers when you want explicit behavior and no enhancement dependency.
-- Prefer `buildTraced()` when you want timing plus spans for the same code path.
+- Prefer `buildTraced()` when you want timing plus child spans for the same code path.
+- Prefer `buildRootTraced()` or `@Timed(span = Timed.SpanMode.ROOT)` for top-level Lambda-style boundaries.
 - `@Timed` is the declarative path when the application uses build-time enhancement.
 - Timers support tags and bucket ranges via `Metrics.timerBuilder(...)` and `@Timed`.

--- a/docs/guides/add-open-telemetry-export.md
+++ b/docs/guides/add-open-telemetry-export.md
@@ -18,7 +18,7 @@ The main decision is **which OpenTelemetry module to use**.
 |---|---|
 | `avaje-metrics-otel` | you want the easiest OTLP-backed setup for avaje metrics and traced timers |
 | `avaje-metrics-otel-producer` | you already own the OpenTelemetry SDK wiring and want collection driven by the SDK reader/exporter |
-| `avaje-metrics-otel-trace` | you only want traced timers / spans and are not exporting avaje metrics via OTEL |
+| `avaje-metrics-otel-trace` | you want traced timers / spans |
 | `avaje-metrics-otel-reporter` | you explicitly want the scheduled reporter path rather than the SDK `MetricProducer` path |
 
 In most new setups, start with **`avaje-metrics-otel`** unless you have a clear reason to
@@ -52,8 +52,7 @@ For a direct Prometheus text endpoint without OpenTelemetry SDK wiring, use
 
 Use this when:
 
-- the goal is spans from `buildTraced()` or `@Timed(span = ON)`
-- avaje metrics are exported some other way, or not exported through OTEL at all
+- the goal is spans from `buildTraced()`, `buildRootTraced()`, or `@Timed(span = Timed.SpanMode.CHILD)` / `ROOT`
 
 ### Scheduled reporter path: `avaje-metrics-otel-reporter`
 
@@ -176,9 +175,10 @@ var openTelemetry = MetricsOpenTelemetry.builder()
   .buildAndRegisterGlobal();
 ```
 
-This controls sampling when Lambda instrumentation or an explicit handler wrapper
-creates an invocation root span. `MetricsOpenTelemetry` does not create that invocation
-span by itself. If there is no current recording span, avaje traced timers are no-op.
+This controls sampling when Lambda instrumentation or `@Timed(span = Timed.SpanMode.ROOT)`
+starts a root span. Use `ROOT` on the top-level handler boundary, then use child traced
+timers inside it. `@Timed(span = Timed.SpanMode.CHILD)` and `buildTraced()` remain no-op
+when there is no current recording span.
 
 ---
 
@@ -235,6 +235,9 @@ var timer = Metrics.timerBuilder("app.service.method")
 
 timer.time(service::run);
 ```
+
+Use `buildRootTraced()` for a top-level boundary that should initiate sampling when no
+recording span is current.
 
 This module does not export avaje metrics to OTEL backends. It only provides the span
 bridge for traced timers.

--- a/docs/guides/configure-metrics-agent.md
+++ b/docs/guides/configure-metrics-agent.md
@@ -117,7 +117,7 @@ nameTrimPackages: com.example
 Tracing default override:
 
 ```text
-timedSpans: default-on
+timedSpans: default-child
 ```
 
 You generally do not need to set `packages`. The built-in filtering skips JDK and
@@ -186,7 +186,7 @@ Avaje HTTP controllers use `web.api` as the default metric base.
 |---|---:|---|
 | `packages` | none | Optional package allow-list. Usually omit this and use the built-in filtering. Values are split on comma, semicolon, or space. Supports `*` and `**` suffixes. |
 | `debugLevel` | `0` | Transform logging verbosity. Use `1` for basic diagnostics and higher values for more detail. |
-| `timedSpans` | `default-off` | Span defaults: `default-off`, `default-on`, or `disabled`. |
+| `timedSpans` | `default-off` | Span defaults: `default-off`, `default-child`, or `disabled`. |
 | `timedMetricNaming` | `full-name` | `full-name` or `label-tag`. |
 | `includeStaticMethods` | `false` | Include static methods when a class is enhanced by default. |
 | `enhanceSingleton` | `true` | Enhance classes annotated with `@Singleton`. |
@@ -259,16 +259,15 @@ method identity as a tag.
 Enhanced methods can create traced timers when trace support is present, such as
 `avaje-metrics-otel-trace`.
 
-`@Timed(span = Timed.SpanMode.ON)` is expected to be most useful in AWS Lambda-style
-applications where method or function boundaries are often the natural span boundary.
-For Kubernetes REST servers, request spans are typically demarcated by an HTTP filter,
-so use enhanced method spans selectively rather than enabling spans broadly for every
-controller method.
+`@Timed(span = Timed.SpanMode.CHILD)` creates child spans under an existing recording
+span, such as a request span created by an HTTP filter. `@Timed(span = Timed.SpanMode.ROOT)`
+creates a root span when there is no current recording span, which is useful for
+top-level AWS Lambda-style handler methods.
 
 Global default:
 
 ```text
-timedSpans: default-on
+timedSpans: default-child
 ```
 
 Disable all enhanced spans:
@@ -280,8 +279,12 @@ timedSpans: disabled
 Override on a class or method:
 
 ```java
-@Timed(span = Timed.SpanMode.ON)
+@Timed(span = Timed.SpanMode.CHILD)
 class BillingService {
+
+  @Timed(span = Timed.SpanMode.ROOT)
+  void lambdaHandler() {
+  }
 
   @Timed(span = Timed.SpanMode.OFF)
   void helper() {

--- a/metrics-otel-producer/README.md
+++ b/metrics-otel-producer/README.md
@@ -142,7 +142,8 @@ Use `avaje-metrics-otel-reporter` when you want the lighter scheduled reporter a
 If you want a convenience module that builds an OTLP-backed `OpenTelemetrySdk` and registers
 `OtelMetricProducer` for you, use `avaje-metrics-otel`.
 
-If you also want traced timers via `Metrics.timerBuilder(...).buildTraced()`, add
+If you also want traced timers via `Metrics.timerBuilder(...).buildTraced()` or
+`buildRootTraced()`, add
 `avaje-metrics-otel-trace`.
 
 ## Important limitation

--- a/metrics-otel-reporter/README.md
+++ b/metrics-otel-reporter/README.md
@@ -9,7 +9,8 @@ The module collects avaje metrics on a configurable schedule and pushes them to 
 
 If you want OpenTelemetry collection time to define the interval instead of a separate avaje
 schedule, use `avaje-metrics-otel-producer` instead. If you also want traced timers via
-`Metrics.timerBuilder(...).buildTraced()`, add `avaje-metrics-otel-trace`.
+`Metrics.timerBuilder(...).buildTraced()` or `buildRootTraced()`, add
+`avaje-metrics-otel-trace`.
 
 ## Maven dependency
 
@@ -162,8 +163,9 @@ reporter.start();
 
 This reporter module does not include the traced-timer span bridge.
 
-If you also want traced timers via `Metrics.timerBuilder(...).buildTraced()` or enhancement with
-`@Timed(span = Timed.SpanMode.ON)` to create OpenTelemetry spans, add
+If you also want traced timers via `Metrics.timerBuilder(...).buildTraced()`,
+`buildRootTraced()`, or enhancement with `@Timed(span = Timed.SpanMode.CHILD)` or `ROOT`,
+add
 `avaje-metrics-otel-trace` separately.
 
 ## Example: avaje-inject

--- a/metrics-otel-trace/README.md
+++ b/metrics-otel-trace/README.md
@@ -3,9 +3,9 @@
 Provides the optional OpenTelemetry span bridge used by traced timers.
 
 When this module is on the classpath or module path,
-`Metrics.timerBuilder(...).buildTraced()`, `MetricRegistry.timerBuilder(...).buildTraced()`,
-and enhancement with `@Timed(span = Timed.SpanMode.ON)` create OpenTelemetry spans via
-`GlobalOpenTelemetry`.
+`Metrics.timerBuilder(...).buildTraced()`, `Metrics.timerBuilder(...).buildRootTraced()`,
+and enhancement with `@Timed(span = Timed.SpanMode.CHILD)` or
+`@Timed(span = Timed.SpanMode.ROOT)` create OpenTelemetry spans via `GlobalOpenTelemetry`.
 
 This module does **not** export avaje metrics to OpenTelemetry metrics backends. For that use:
 
@@ -41,6 +41,11 @@ Timer timer = Metrics.timerBuilder("app.service.method")
   .bucketRanges(50, 100, 250)
   .buildTraced();
 ```
+
+Use `buildRootTraced()` or `@Timed(span = Timed.SpanMode.ROOT)` on a top-level boundary
+that should start a root span when no recording span is current. Root traced timers use
+the default OpenTelemetry `INTERNAL` span kind and make the span current for the timed
+operation.
 
 When a traced timer includes a `label:...` tag, that label is used as the span name while the
 aggregated metric name remains available via the `avaje.metrics.name` attribute.

--- a/metrics-otel-trace/src/main/java/io/avaje/metrics/otel/trace/OtelSpan.java
+++ b/metrics-otel-trace/src/main/java/io/avaje/metrics/otel/trace/OtelSpan.java
@@ -1,25 +1,35 @@
 package io.avaje.metrics.otel.trace;
 
 import io.avaje.metrics.spi.SpiSpan;
+import io.opentelemetry.context.Scope;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
+import org.jspecify.annotations.Nullable;
 
 final class OtelSpan implements SpiSpan {
 
   private final Span span;
+  private final @Nullable Scope scope;
 
   OtelSpan(Span span) {
+    this(span, null);
+  }
+
+  OtelSpan(Span span, @Nullable Scope scope) {
     this.span = span;
+    this.scope = scope;
   }
 
   @Override
   public void end() {
+    closeScope();
     span.end();
   }
 
   @Override
   public void endWithError() {
     span.setStatus(StatusCode.ERROR);
+    closeScope();
     span.end();
   }
 
@@ -27,5 +37,11 @@ final class OtelSpan implements SpiSpan {
   public void endWithError(Throwable error) {
     span.recordException(error);
     endWithError();
+  }
+
+  private void closeScope() {
+    if (scope != null) {
+      scope.close();
+    }
   }
 }

--- a/metrics-otel-trace/src/main/java/io/avaje/metrics/otel/trace/OtelTimedSpanFactory.java
+++ b/metrics-otel-trace/src/main/java/io/avaje/metrics/otel/trace/OtelTimedSpanFactory.java
@@ -19,7 +19,12 @@ public final class OtelTimedSpanFactory implements SpiTimedSpanFactory {
 
   @Override
   public @Nullable Prepared prepare(Metric.ID id, @Nullable String bucketRange) {
-    return new PreparedSpan(spanName(id), attributes(id, bucketRange));
+    return prepare(id, bucketRange, SpanMode.CHILD);
+  }
+
+  @Override
+  public @Nullable Prepared prepare(Metric.ID id, @Nullable String bucketRange, SpanMode spanMode) {
+    return new PreparedSpan(spanName(id), attributes(id, bucketRange), spanMode);
   }
 
   private String spanName(Metric.ID id) {
@@ -55,15 +60,21 @@ public final class OtelTimedSpanFactory implements SpiTimedSpanFactory {
 
     private final String spanName;
     private final Attributes attributes;
+    private final SpanMode spanMode;
 
-    private PreparedSpan(String spanName, Attributes attributes) {
+    private PreparedSpan(String spanName, Attributes attributes, SpanMode spanMode) {
       this.spanName = spanName;
       this.attributes = attributes;
+      this.spanMode = spanMode;
     }
 
     @Override
     public @Nullable OtelSpan start() {
-      if (!Span.current().isRecording()) {
+      var currentSpan = Span.current();
+      if (spanMode == SpanMode.CHILD && !currentSpan.isRecording()) {
+        return null;
+      }
+      if (spanMode == SpanMode.ROOT && !currentSpan.isRecording() && currentSpan.getSpanContext().isValid()) {
         return null;
       }
       var span = GlobalOpenTelemetry.get()
@@ -71,7 +82,7 @@ public final class OtelTimedSpanFactory implements SpiTimedSpanFactory {
         .spanBuilder(spanName)
         .setAllAttributes(attributes)
         .startSpan();
-      return new OtelSpan(span);
+      return spanMode == SpanMode.ROOT ? new OtelSpan(span, span.makeCurrent()) : new OtelSpan(span);
     }
   }
 }

--- a/metrics-otel-trace/src/main/java/module-info.java
+++ b/metrics-otel-trace/src/main/java/module-info.java
@@ -4,6 +4,7 @@ module io.avaje.metrics.otel.trace {
 
   requires io.avaje.metrics;
   requires static io.opentelemetry.api;
+  requires static io.opentelemetry.context;
 
   provides io.avaje.metrics.spi.SpiTimedSpanFactory with io.avaje.metrics.otel.trace.OtelTimedSpanFactory;
 }

--- a/metrics-otel-trace/src/test/java/io/avaje/metrics/otel/trace/OtelTimedSpanFactoryTest.java
+++ b/metrics-otel-trace/src/test/java/io/avaje/metrics/otel/trace/OtelTimedSpanFactoryTest.java
@@ -7,8 +7,13 @@ import io.avaje.metrics.Tags;
 import io.avaje.metrics.Timer;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.api.trace.TraceFlags;
+import io.opentelemetry.api.trace.TraceState;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.testing.exporter.InMemorySpanExporter;
 import io.opentelemetry.sdk.trace.SdkTracerProvider;
@@ -19,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -166,6 +172,89 @@ class OtelTimedSpanFactoryTest {
     registry.timerBuilder("app.service.method").buildTraced().time(() -> "ok");
 
     assertThat(exporter.getFinishedSpanItems()).isEmpty();
+  }
+
+  @Test
+  void rootTracedTimer_withoutParent_startsRootSpanAndMakesItCurrent() {
+    MetricRegistry registry = Metrics.createRegistry();
+    Timer timer = registry.timerBuilder("app.lambda.handle").buildRootTraced();
+    var currentWasRecording = new AtomicReference<Boolean>();
+
+    timer.time(() -> {
+      currentWasRecording.set(Span.current().isRecording());
+      return "ok";
+    });
+
+    List<SpanData> spans = exporter.getFinishedSpanItems();
+    assertThat(currentWasRecording).hasValue(true);
+    assertThat(spans).singleElement().satisfies(span -> {
+      assertThat(span.getName()).isEqualTo("app.lambda.handle");
+      assertThat(span.getKind()).isEqualTo(SpanKind.INTERNAL);
+      assertThat(span.getParentSpanContext().isValid()).isFalse();
+    });
+  }
+
+  @Test
+  void rootTracedTimer_withRecordingParent_createsChildSpan() {
+    MetricRegistry registry = Metrics.createRegistry();
+    Timer timer = registry.timerBuilder("app.lambda.handle").buildRootTraced();
+    var parent = openTelemetry.getTracer("test").spanBuilder("parent").startSpan();
+
+    try (Scope ignored = parent.makeCurrent()) {
+      timer.time(() -> "ok");
+    } finally {
+      parent.end();
+    }
+
+    List<SpanData> spans = exporter.getFinishedSpanItems();
+    assertThat(spans).hasSize(2);
+    SpanData parentSpan = spans.stream()
+      .filter(it -> it.getName().equals("parent"))
+      .findFirst()
+      .orElseThrow();
+    SpanData childSpan = spans.stream()
+      .filter(it -> it.getName().equals("app.lambda.handle"))
+      .findFirst()
+      .orElseThrow();
+    assertThat(childSpan.getParentSpanId()).isEqualTo(parentSpan.getSpanId());
+  }
+
+  @Test
+  void rootTracedTimer_withUnsampledValidParent_doesNotStartNewRoot() {
+    MetricRegistry registry = Metrics.createRegistry();
+    Timer timer = registry.timerBuilder("app.lambda.handle").buildRootTraced();
+    var unsampledParent = Span.wrap(SpanContext.create(
+      "00000000000000000000000000000001",
+      "0000000000000001",
+      TraceFlags.getDefault(),
+      TraceState.getDefault()));
+
+    try (Scope ignored = unsampledParent.makeCurrent()) {
+      timer.time(() -> "ok");
+    }
+
+    assertThat(exporter.getFinishedSpanItems()).isEmpty();
+  }
+
+  @Test
+  void childTracedTimer_underRootTracedTimer_createsChildSpan() {
+    MetricRegistry registry = Metrics.createRegistry();
+    Timer rootTimer = registry.timerBuilder("app.lambda.handle").buildRootTraced();
+    Timer childTimer = registry.timerBuilder("app.service.method").buildTraced();
+
+    rootTimer.time(() -> childTimer.time(() -> "ok"));
+
+    List<SpanData> spans = exporter.getFinishedSpanItems();
+    assertThat(spans).hasSize(2);
+    SpanData rootSpan = spans.stream()
+      .filter(it -> it.getName().equals("app.lambda.handle"))
+      .findFirst()
+      .orElseThrow();
+    SpanData childSpan = spans.stream()
+      .filter(it -> it.getName().equals("app.service.method"))
+      .findFirst()
+      .orElseThrow();
+    assertThat(childSpan.getParentSpanId()).isEqualTo(rootSpan.getSpanId());
   }
 
   @Test

--- a/metrics-otel/README.md
+++ b/metrics-otel/README.md
@@ -45,7 +45,7 @@ This helper configures:
   - a batch span processor
   - an OTLP gRPC span exporter
 - the traced-timer bridge used by traced timers created via
-  `Metrics.timerBuilder(...).buildTraced()`
+  `Metrics.timerBuilder(...).buildTraced()` or `buildRootTraced()`
 
 ## Builder options
 
@@ -153,10 +153,11 @@ MetricsOpenTelemetry.builder()
   .buildAndRegisterGlobal();
 ```
 
-This configures the SDK sampler. It does not create the Lambda invocation root span by
-itself. If Lambda instrumentation or a handler wrapper creates a current invocation
-span, avaje traced timers become child spans and follow that sampling decision. If
-there is no current recording span, traced timers are no-op.
+This configures the SDK sampler. Use `@Timed(span = Timed.SpanMode.ROOT)` or
+`buildRootTraced()` on the top-level handler boundary to start a root span when no
+recording span is current. Child traced timers then follow that root sampling decision.
+`@Timed(span = Timed.SpanMode.CHILD)` and `buildTraced()` remain no-op when there is no
+current recording span.
 
 You can also provide custom exporters when you need OTLP-specific configuration such as headers,
 compression, or timeouts:
@@ -182,8 +183,9 @@ OpenTelemetrySdk sdk =
 - Normal OpenTelemetry meters and tracers created from the returned SDK are exported alongside the
   avaje metrics exposed by `OtelMetricProducer`.
 - Resource attributes apply to both metrics and spans.
-- traced timers created via `Metrics.timerBuilder(...).buildTraced()` work by default because this
-  module brings in `avaje-metrics-otel-trace`.
+- traced timers created via `Metrics.timerBuilder(...).buildTraced()` or
+  `buildRootTraced()` work by default because this module brings in
+  `avaje-metrics-otel-trace`.
 - `includeTrace(false)` or `includeMeter(false)` can be used for metrics-only or traces-only setup.
 - If you want more control over SDK setup, wire OpenTelemetry manually and use
   `avaje-metrics-otel-producer` directly.

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -85,6 +85,9 @@ var timer = Metrics.timerBuilder("app.service.run")
   .buildTraced();
 ```
 
+Use `buildRootTraced()` for a top-level boundary that should create a root span when no
+recording span is current.
+
 `@Timed` is the declarative path when build-time enhancement is enabled in the
 application. See [Configure metrics enhancement](../docs/guides/configure-metrics-agent.md)
 for `metrics-maven-plugin` and `metrics.mf` setup.

--- a/metrics/src/main/java/io/avaje/metrics/Timer.java
+++ b/metrics/src/main/java/io/avaje/metrics/Timer.java
@@ -63,8 +63,8 @@ import java.util.function.Supplier;
  * </pre>
  *
  * <p>
- * Timers built via {@link Metrics#timerBuilder(String)} and {@link TimerBuilder#buildTraced()}
- * create spans when used with {@link #startEvent()} or
+ * Timers built via {@link Metrics#timerBuilder(String)}, {@link TimerBuilder#buildTraced()} or
+ * {@link TimerBuilder#buildRootTraced()} create spans when used with {@link #startEvent()} or
  * {@link #time(Runnable)} / {@link #time(Supplier)}.
  */
 public interface Timer extends Metric {

--- a/metrics/src/main/java/io/avaje/metrics/TimerBuilder.java
+++ b/metrics/src/main/java/io/avaje/metrics/TimerBuilder.java
@@ -30,7 +30,18 @@ public interface TimerBuilder {
   Timer build();
 
   /**
-   * Create and register a traced timer.
+   * Create and register a child traced timer.
+   * <p>
+   * Child traced timers create spans only when there is an existing recording span.
    */
   Timer buildTraced();
+
+  /**
+   * Create and register a root traced timer.
+   * <p>
+   * Root traced timers create a root span when there is no current recording span. If there is a
+   * current recording span, they create a child span. If there is a valid unsampled current span,
+   * they do not create a new root span.
+   */
+  Timer buildRootTraced();
 }

--- a/metrics/src/main/java/io/avaje/metrics/annotation/Timed.java
+++ b/metrics/src/main/java/io/avaje/metrics/annotation/Timed.java
@@ -29,9 +29,13 @@ public @interface Timed {
      */
     DEFAULT,
     /**
-     * Create spans for timed methods.
+     * Create child spans under an existing recording span.
      */
-    ON,
+    CHILD,
+    /**
+     * Create a root span when no recording span exists.
+     */
+    ROOT,
     /**
      * Do not create spans for timed methods.
      */

--- a/metrics/src/main/java/io/avaje/metrics/core/DBucketTimer.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DBucketTimer.java
@@ -4,6 +4,7 @@ import io.avaje.metrics.Timer;
 import io.avaje.metrics.spi.SpiSpan;
 import io.avaje.metrics.spi.SpiTimedSpanFactory.Prepared;
 import io.avaje.metrics.spi.SpiTimedSpanFactory;
+import io.avaje.metrics.spi.SpiTimedSpanFactory.SpanMode;
 import org.jspecify.annotations.Nullable;
 
 import java.util.function.Supplier;
@@ -165,11 +166,11 @@ final class DBucketTimer implements Timer, TraceableTimer {
   }
 
   @Override
-  public Timer withTracing(@Nullable SpiTimedSpanFactory timedSpanFactory) {
+  public Timer withTracing(@Nullable SpiTimedSpanFactory timedSpanFactory, SpanMode spanMode) {
     if (this.preparedSpan != null || timedSpanFactory == null) {
       return this;
     }
-    var prepared = timedSpanFactory.prepare(id, null);
+    var prepared = timedSpanFactory.prepare(id, null, spanMode);
     if (prepared == null) {
       return this;
     }

--- a/metrics/src/main/java/io/avaje/metrics/core/DTimer.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DTimer.java
@@ -4,6 +4,7 @@ import io.avaje.metrics.Timer;
 import io.avaje.metrics.spi.SpiSpan;
 import io.avaje.metrics.spi.SpiTimedSpanFactory.Prepared;
 import io.avaje.metrics.spi.SpiTimedSpanFactory;
+import io.avaje.metrics.spi.SpiTimedSpanFactory.SpanMode;
 import org.jspecify.annotations.Nullable;
 
 import java.util.concurrent.TimeUnit;
@@ -180,11 +181,11 @@ final class DTimer implements Timer, TraceableTimer {
   }
 
   @Override
-  public Timer withTracing(@Nullable SpiTimedSpanFactory timedSpanFactory) {
+  public Timer withTracing(@Nullable SpiTimedSpanFactory timedSpanFactory, SpanMode spanMode) {
     if (this.preparedSpan != null || timedSpanFactory == null) {
       return this;
     }
-    var prepared = timedSpanFactory.prepare(id, bucketRange);
+    var prepared = timedSpanFactory.prepare(id, bucketRange, spanMode);
     if (prepared == null) {
       return this;
     }

--- a/metrics/src/main/java/io/avaje/metrics/core/DefaultMetricProvider.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/DefaultMetricProvider.java
@@ -4,6 +4,7 @@ import io.avaje.metrics.*;
 import io.avaje.metrics.spi.SpiMetricBuilder;
 import io.avaje.metrics.spi.SpiMetricProvider;
 import io.avaje.metrics.spi.SpiTimedSpanFactory;
+import io.avaje.metrics.spi.SpiTimedSpanFactory.SpanMode;
 import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
@@ -320,11 +321,20 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
   }
 
   private Timer tracedTimer(String name, Tags tags, @Nullable int[] bucketRanges) {
+    return tracedTimer(name, tags, bucketRanges, SpanMode.CHILD);
+  }
+
+  private Timer rootTracedTimer(String name, Tags tags, @Nullable int[] bucketRanges) {
+    return tracedTimer(name, tags, bucketRanges, SpanMode.ROOT);
+  }
+
+  private Timer tracedTimer(String name, Tags tags, @Nullable int[] bucketRanges, SpanMode spanMode) {
     return tracedMetric(
       Metric.ID.of(name, tags),
       TIMER_UNIT,
       timerFactory(bucketRanges),
-      bucketRanges);
+      bucketRanges,
+      spanMode);
   }
 
   private <T extends Metric> T metric(
@@ -350,7 +360,12 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
     return validateMetric(id, metric, type, normalizedUnit);
   }
 
-  private Timer tracedMetric(Metric.ID id, String unit, SpiMetricBuilder.Factory<?> factory, int[] bucketRanges) {
+  private Timer tracedMetric(
+      Metric.ID id,
+      String unit,
+      SpiMetricBuilder.Factory<?> factory,
+      @Nullable int[] bucketRanges,
+      SpanMode spanMode) {
     var normalizedUnit = BaseReportName.normalizeUnit(unit);
     Metric metric = metricsCache.get(id);
     if (metric == null) {
@@ -359,7 +374,7 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
         if (metric == null) {
           metric = factory.createMetric(id, normalizedUnit, bucketRanges);
           if (metric instanceof TraceableTimer) {
-            metric = ((TraceableTimer) metric).withTracing(timedSpanFactory);
+            metric = ((TraceableTimer) metric).withTracing(timedSpanFactory, spanMode);
           }
           metricsCache.put(id, metric);
         }
@@ -540,6 +555,11 @@ public final class DefaultMetricProvider implements SpiMetricProvider {
     @Override
     public Timer buildTraced() {
       return tracedTimer(name, tags, bucketRanges);
+    }
+
+    @Override
+    public Timer buildRootTraced() {
+      return rootTracedTimer(name, tags, bucketRanges);
     }
   }
 

--- a/metrics/src/main/java/io/avaje/metrics/core/TraceableTimer.java
+++ b/metrics/src/main/java/io/avaje/metrics/core/TraceableTimer.java
@@ -2,6 +2,7 @@ package io.avaje.metrics.core;
 
 import io.avaje.metrics.Timer;
 import io.avaje.metrics.spi.SpiTimedSpanFactory;
+import io.avaje.metrics.spi.SpiTimedSpanFactory.SpanMode;
 import org.jspecify.annotations.Nullable;
 
 interface TraceableTimer {
@@ -9,5 +10,5 @@ interface TraceableTimer {
   /**
    * Return this timer with tracing enabled if supported.
    */
-  Timer withTracing(@Nullable SpiTimedSpanFactory timedSpanFactory);
+  Timer withTracing(@Nullable SpiTimedSpanFactory timedSpanFactory, SpanMode spanMode);
 }

--- a/metrics/src/main/java/io/avaje/metrics/spi/SpiTimedSpanFactory.java
+++ b/metrics/src/main/java/io/avaje/metrics/spi/SpiTimedSpanFactory.java
@@ -9,12 +9,37 @@ import org.jspecify.annotations.Nullable;
 public interface SpiTimedSpanFactory {
 
   /**
+   * The span creation mode requested by a traced timer.
+   */
+  enum SpanMode {
+    /**
+     * Create spans only under an existing recording span.
+     */
+    CHILD,
+    /**
+     * Create a root span when no recording span exists.
+     */
+    ROOT
+  }
+
+  /**
    * Prepare a span starter for the given timer.
    *
    * @param id the timer metric id
    * @param bucketRange the bucket range when the timer represents a bucketed series
    */
   @Nullable Prepared prepare(Metric.ID id, @Nullable String bucketRange);
+
+  /**
+   * Prepare a span starter for the given timer and span mode.
+   *
+   * @param id the timer metric id
+   * @param bucketRange the bucket range when the timer represents a bucketed series
+   * @param spanMode the requested span creation mode
+   */
+  default @Nullable Prepared prepare(Metric.ID id, @Nullable String bucketRange, SpanMode spanMode) {
+    return prepare(id, bucketRange);
+  }
 
   /**
    * A prepared span starter for a specific metric id and bucket range.

--- a/metrics/src/test/java/io/avaje/metrics/core/TracedTimerTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/core/TracedTimerTest.java
@@ -6,8 +6,11 @@ import io.avaje.metrics.Metrics;
 import io.avaje.metrics.Timer;
 import io.avaje.metrics.spi.SpiSpan;
 import io.avaje.metrics.spi.SpiTimedSpanFactory;
+import io.avaje.metrics.spi.SpiTimedSpanFactory.SpanMode;
 import org.junit.jupiter.api.Test;
 
+import static io.avaje.metrics.spi.SpiTimedSpanFactory.SpanMode.CHILD;
+import static io.avaje.metrics.spi.SpiTimedSpanFactory.SpanMode.ROOT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -30,7 +33,7 @@ class TracedTimerTest {
   void withTracing_returnsImmutableTracedTimer() {
     Timer plainTimer = new DTimer(Metric.ID.of("app.service.method"));
     TestTimedSpanFactory testTimedSpanFactory = new TestTimedSpanFactory();
-    Timer tracedTimer = ((TraceableTimer) plainTimer).withTracing(testTimedSpanFactory);
+    Timer tracedTimer = ((TraceableTimer) plainTimer).withTracing(testTimedSpanFactory, CHILD);
 
     tracedTimer.time(() -> "ok");
     tracedTimer.time(() -> "ok");
@@ -61,7 +64,7 @@ class TracedTimerTest {
   @Test
   void tracedTimer_startEvent_errorRecordsThrowable() {
     TestTimedSpanFactory testTimedSpanFactory = new TestTimedSpanFactory();
-    Timer tracedTimer = ((TraceableTimer) new DTimer(Metric.ID.of("app.service.method"))).withTracing(testTimedSpanFactory);
+    Timer tracedTimer = ((TraceableTimer) new DTimer(Metric.ID.of("app.service.method"))).withTracing(testTimedSpanFactory, CHILD);
     var error = new IllegalStateException("boom");
 
     Timer.Event event = tracedTimer.startEvent();
@@ -73,7 +76,7 @@ class TracedTimerTest {
   @Test
   void tracedTimer_time_errorRecordsThrowable() {
     TestTimedSpanFactory testTimedSpanFactory = new TestTimedSpanFactory();
-    Timer tracedTimer = ((TraceableTimer) new DTimer(Metric.ID.of("app.service.method"))).withTracing(testTimedSpanFactory);
+    Timer tracedTimer = ((TraceableTimer) new DTimer(Metric.ID.of("app.service.method"))).withTracing(testTimedSpanFactory, CHILD);
     var error = new IllegalStateException("boom");
 
     assertThatThrownBy(() -> tracedTimer.time(() -> {
@@ -87,7 +90,7 @@ class TracedTimerTest {
   void tracedBucketTimer_errorRecordsThrowable() {
     TestTimedSpanFactory testTimedSpanFactory = new TestTimedSpanFactory();
     Timer bucketTimer = new BucketTimerFactory().createMetric(Metric.ID.of("app.service.bucketed"), "", new int[]{100, 200});
-    Timer tracedBucketTimer = ((TraceableTimer) bucketTimer).withTracing(testTimedSpanFactory);
+    Timer tracedBucketTimer = ((TraceableTimer) bucketTimer).withTracing(testTimedSpanFactory, CHILD);
     var error = new IllegalArgumentException("bad");
 
     Timer.Event event = tracedBucketTimer.startEvent();
@@ -96,15 +99,32 @@ class TracedTimerTest {
     assertThat(testTimedSpanFactory.lastSpan.error).isSameAs(error);
   }
 
+  @Test
+  void withTracing_passesRootSpanMode() {
+    TestTimedSpanFactory testTimedSpanFactory = new TestTimedSpanFactory();
+    Timer tracedTimer = ((TraceableTimer) new DTimer(Metric.ID.of("app.service.method"))).withTracing(testTimedSpanFactory, ROOT);
+
+    tracedTimer.time(() -> "ok");
+
+    assertThat(testTimedSpanFactory.lastSpanMode).isEqualTo(ROOT);
+  }
+
   private static final class TestTimedSpanFactory implements SpiTimedSpanFactory {
 
     private int prepareCount;
     private int startCount;
     private TestTimedSpan lastSpan;
+    private SpanMode lastSpanMode;
 
     @Override
     public Prepared prepare(Metric.ID id, String bucketRange) {
+      return prepare(id, bucketRange, CHILD);
+    }
+
+    @Override
+    public Prepared prepare(Metric.ID id, String bucketRange, SpanMode spanMode) {
       prepareCount++;
+      lastSpanMode = spanMode;
       return () -> {
         startCount++;
         lastSpan = new TestTimedSpan();


### PR DESCRIPTION
We can use ROOT spans on top level Lambda functions such that they initiate spans based on sampling rate. Noting that CHILD spans do not initiate spans but only get creating when an recording parent span.