### PR TITLE
[open telemetry] Add waitIfRunning() option for lambda reporting

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -46,6 +46,7 @@ Step-by-step guides written as instructions for AI agents and developers working
 | Guide | Description |
 |-------|-------------|
 | [Add OpenTelemetry export](add-open-telemetry-export.md) | Choose between `avaje-metrics-otel`, `avaje-metrics-otel-producer`, `avaje-metrics-otel-trace`, and `avaje-metrics-otel-reporter` and wire the right OTEL path |
+| [Add OpenTelemetry export — AWS Lambda](add-open-telemetry-lambda.md) | Configure `avaje-metrics-otel` for AWS Lambda using `enableWaitIfRunning()` so freeze-on-exit and low-traffic invocations do not lose metrics |
 | [Add Prometheus scraping](add-prometheus-scrape.md) | Add `avaje-metrics-prometheus` and expose a pull-based Prometheus text endpoint using cumulative collection |
 | [Add StatsD reporting](add-statsd-reporting.md) | Add `avaje-metrics-statsd`, configure `StatsdReporter`, and export avaje-metrics data to StatsD / DogStatsD |
 | [Add Graphite reporting](add-graphite-reporting.md) | Add `avaje-metrics-graphite`, configure `GraphiteReporter`, and export avaje-metrics data to Graphite |
@@ -76,7 +77,7 @@ Below are copy-paste snippets for the most common AI tooling configurations.
 
 This project uses [avaje-metrics](https://avaje-metrics.github.io). Step-by-step guides
 for common tasks (getting started, JVM metrics, method timing, metrics enhancement configuration,
-OpenTelemetry export, Prometheus scraping, StatsD reporting, Graphite reporting, Ebean metrics)
+OpenTelemetry export, OpenTelemetry export for AWS Lambda, Prometheus scraping, StatsD reporting, Graphite reporting, Ebean metrics)
 are at:
 
 **https://github.com/avaje/avaje-metrics/tree/HEAD/docs/guides/**
@@ -89,7 +90,7 @@ are at:
 
 This project uses [avaje-metrics](https://avaje-metrics.github.io). Step-by-step guides
 for common tasks (getting started, JVM metrics, method timing, metrics enhancement configuration,
-OpenTelemetry export, Prometheus scraping, StatsD reporting, Graphite reporting, Ebean metrics)
+OpenTelemetry export, OpenTelemetry export for AWS Lambda, Prometheus scraping, StatsD reporting, Graphite reporting, Ebean metrics)
 are at:
 
 **https://github.com/avaje/avaje-metrics/tree/HEAD/docs/guides/**
@@ -113,6 +114,7 @@ Key guides (fetch and follow when performing the relevant task):
 - Add method timing: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-method-timing.md
 - Configure metrics enhancement: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/configure-metrics-agent.md
 - Add OpenTelemetry export: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-open-telemetry-export.md
+- Add OpenTelemetry export — AWS Lambda: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-open-telemetry-lambda.md
 - Add Prometheus scraping: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-prometheus-scrape.md
 - Add StatsD reporting: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-statsd-reporting.md
 - Add Graphite reporting: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-graphite-reporting.md

--- a/docs/guides/add-open-telemetry-export.md
+++ b/docs/guides/add-open-telemetry-export.md
@@ -307,6 +307,10 @@ OpenTelemetry backend or collector.
 ## Notes
 
 - `avaje-metrics-otel` is the best default for new OTLP-backed setups.
+- For **AWS Lambda** (or other freeze-on-exit serverless runtimes) follow
+  [add-open-telemetry-lambda.md](add-open-telemetry-lambda.md) — the
+  `enableWaitIfRunning()` builder option is essential to avoid losing metrics on
+  Lambda freeze.
 - `avaje-metrics-otel-producer` is the right choice when the application already owns the SDK.
 - `avaje-metrics-otel-trace` is trace-only.
 - `avaje-metrics-otel-reporter` is a separate scheduled path and should be used intentionally.

--- a/docs/guides/add-open-telemetry-lambda.md
+++ b/docs/guides/add-open-telemetry-lambda.md
@@ -1,0 +1,315 @@
+# Guide: Add OpenTelemetry Export — AWS Lambda
+
+## Purpose
+
+This guide provides step-by-step instructions for exporting **avaje-metrics** data
+(and related traces) to OpenTelemetry from an **AWS Lambda** function (or any similar
+"freeze-on-exit" serverless runtime).
+
+When asked to *"export Lambda metrics to OpenTelemetry"*, *"why are my Lambda metrics
+missing in Grafana / Mimir / Tempo"*, or *"add `enableWaitIfRunning()` to a Lambda
+function"*, follow these steps exactly.
+
+This guide is the Lambda-specific companion to
+[add-open-telemetry-export.md](add-open-telemetry-export.md). Read that one first if
+you have not yet decided which OTEL module to use.
+
+---
+
+## Overview
+
+AWS Lambda freezes the worker between invocations. Two consequences matter for
+OpenTelemetry:
+
+1. **Freeze-on-exit cuts in-flight exports mid-flight.** The default
+   `PeriodicMetricReader` and `BatchSpanProcessor` background threads ship telemetry
+   asynchronously. If the runtime suspends while an OTLP HTTP/gRPC export is in
+   progress, the request is interrupted. The export *may* complete on a later thaw,
+   minutes later — or be lost.
+
+2. **Low-traffic Lambdas starve the periodic reader.** A Lambda invoked once a
+   minute spends most of its life frozen. The periodic reader cannot tick on a
+   reliable schedule, so metrics produced inside an invocation may never be exported
+   before the runtime is suspended again.
+
+`avaje-metrics-otel` solves both with a single builder call:
+
+```java
+.enableWaitIfRunning()
+```
+
+This wraps the metric and span exporters to track in-flight exports and provides a
+`TelemetryWaiter` that, at the **end** of an invocation:
+
+1. **Waits** briefly if a scheduled background export is currently in progress, and
+2. **Force-flushes** telemetry that has gone stale (no successful background export
+   within the configured `flushIfStale` window).
+
+In busy environments the periodic reader keeps `lastSuccess` fresh and the stale
+forceFlush is a no-op. In low-traffic environments the stale forceFlush ships data on
+the invocation thread before the runtime is suspended again.
+
+The pattern mirrors the avaje-metrics StatsD `waitIfRunning()` pattern: most
+invocations have zero overhead; only an invocation that overlaps an active export, or
+arrives after a long quiet period, pays a brief synchronous cost.
+
+---
+
+## Step 1 — Add the dependency
+
+```xml
+<dependency>
+  <groupId>io.avaje</groupId>
+  <artifactId>avaje-metrics-otel</artifactId>
+  <version>${version}</version>
+</dependency>
+```
+
+This is the same module as the standard OTEL recipe — Lambda support is built in.
+
+---
+
+## Step 2 — Build the SDK once at handler-class init
+
+Build the `OpenTelemetrySdk` and `TelemetryWaiter` **once** when the Lambda handler
+class is loaded — not per invocation. The Lambda runtime reuses the same handler
+instance across invocations on the same warm worker.
+
+```java
+import io.avaje.metrics.otel.MetricsOpenTelemetry;
+import io.avaje.metrics.otel.TelemetryWaiter;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+public class OrdersHandler {
+
+  private static final TelemetryWaiter WAITER;
+
+  static {
+    var result = MetricsOpenTelemetry.builder()
+        .protocol(MetricsOpenTelemetry.Protocol.HTTP_PROTOBUF)
+        .endpoint(System.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+        .serviceName("orders-lambda")
+        .deploymentEnvironmentName(System.getenv("ENV"))
+        .exportTimeout(Duration.ofSeconds(5))
+        .connectTimeout(Duration.ofSeconds(2))
+        .enableWaitIfRunning()
+            .timeout(35, TimeUnit.SECONDS)
+            // .flushIfStale(Duration.ofSeconds(60))  // optional
+            .buildAndRegisterGlobal();
+
+    WAITER = result.waiter();
+  }
+
+  public Response handle(Request request) {
+    try {
+      return process(request);
+    } finally {
+      WAITER.waitIfRunning();
+    }
+  }
+}
+```
+
+The two critical pieces are:
+
+- `enableWaitIfRunning()` — wraps the exporters and produces the waiter.
+- `WAITER.waitIfRunning()` in a `finally` block — runs at the end of every
+  invocation, blocks briefly only if needed.
+
+If you have multiple Lambda handler classes in the same deployment artifact (e.g. an
+event handler **and** a schedule handler), build the SDK in a shared class so all
+handlers use the same `TelemetryWaiter` instance.
+
+---
+
+## Step 3 — Understand the Lambda-friendly defaults
+
+Calling `enableWaitIfRunning()` switches two defaults to Lambda-friendly values, but
+only when the caller has not already set them explicitly:
+
+| Setting              | Standalone default | Lambda default               | Why |
+|----------------------|--------------------|------------------------------|-----|
+| `meterInterval`      | 60 seconds         | **30 seconds**               | Faster ticks reduce stale-flush frequency in low-traffic envs. |
+| `flushIfStale`       | n/a                | **2 × meterInterval** (60 s) | Forgives one missed tick + jitter; flushes when two or more are missed. |
+| `WaiterBuilder.timeout` | 5 seconds       | 5 seconds (set higher)       | Lambda freezes mid-export are common — recommend **35 s**. |
+| `connectTimeout`     | unset (10 s SDK)   | recommend **2 s**            | Fail fast on networking issues so they don't burn invocation time. |
+| `exportTimeout`      | unset (10 s SDK)   | recommend **5 s**            | Same. |
+
+You can override any of these. Pass `Duration.ZERO` to `flushIfStale(...)` to disable
+the stale forceFlush and use only the in-flight wait behaviour.
+
+### How `flushIfStale` works
+
+The waiter records `lastSuccessAtMillis` whenever a wrapped export completes
+successfully. At the end of `waitIfRunning()`:
+
+1. If `(now - lastSuccess) > flushIfStale` for metrics, call `SdkMeterProvider.forceFlush()`.
+2. If `(now - lastSuccess) > flushIfStale` for spans, call `SdkTracerProvider.forceFlush()`.
+
+`lastSuccess` starts at `0`, so the **first invocation after cold start** always
+triggers a forceFlush — this is intentional, and ships startup metrics promptly.
+
+---
+
+## Step 4 — Wiring with dependency injection
+
+### Spring
+
+```java
+@Configuration
+public class MetricsConfig {
+
+  @Bean
+  OpenTelemetry openTelemetry() {
+    var result = MetricsOpenTelemetry.builder()
+        .endpoint(System.getenv("OTEL_EXPORTER_OTLP_ENDPOINT"))
+        .protocol(MetricsOpenTelemetry.Protocol.HTTP_PROTOBUF)
+        .serviceName("orders-lambda")
+        .exportTimeout(Duration.ofSeconds(5))
+        .enableWaitIfRunning()
+            .timeout(35, TimeUnit.SECONDS)
+            .buildAndRegisterGlobal();
+    this.waiter = result.waiter();
+    return result.sdk();
+  }
+
+  @Bean
+  TelemetryWaiter telemetryWaiter() {
+    return waiter;   // captured above
+  }
+
+  private TelemetryWaiter waiter;
+}
+```
+
+### avaje-inject
+
+```java
+@Factory
+public class MetricsConfig {
+
+  private TelemetryWaiter waiter;
+
+  @Bean
+  OpenTelemetry openTelemetry() {
+    var result = MetricsOpenTelemetry.builder()
+        .endpoint(Config.getNullable("otel.endpoint"))
+        .protocol(MetricsOpenTelemetry.Protocol.HTTP_PROTOBUF)
+        .serviceName("orders-lambda")
+        .exportTimeout(Duration.ofSeconds(5))
+        .enableWaitIfRunning()
+            .timeout(Config.getInt("otel.waitTimeoutMillis", 35_000), TimeUnit.MILLISECONDS)
+            .buildAndRegisterGlobal();
+    this.waiter = result.waiter();
+    return result.sdk();
+  }
+
+  @Bean
+  TelemetryWaiter telemetryWaiter() {
+    return waiter;
+  }
+}
+```
+
+In the handler:
+
+```java
+public class OrdersLambda {
+
+  private final TelemetryWaiter waiter;
+  // ... other deps
+
+  public Response handle(Request request) {
+    try {
+      return process(request);
+    } finally {
+      waiter.waitIfRunning();
+    }
+  }
+}
+```
+
+When OTEL is disabled (e.g. in a local dev profile that does not configure an
+endpoint), inject `TelemetryWaiter.noop()` instead — the same handler code keeps
+working with zero overhead.
+
+---
+
+## Step 5 — Verify
+
+Enable DEBUG logging on the `io.avaje.metrics.otel` logger (or your application's
+matching package) so you can see the export lifecycle. With `avaje-simple-logger`:
+
+```properties
+log.level.io.avaje.metrics.otel=DEBUG
+```
+
+You should see a sequence like this on a healthy warm invocation:
+
+```
+DEBUG io.avaje.metrics.otel - OTLP metric export starting count:90
+DEBUG io.avaje.metrics.otel - OTLP metric export completed count:90 elapsedMs:219
+```
+
+On the first invocation after cold start (or after a quiet period):
+
+```
+DEBUG io.avaje.metrics.otel - OTLP metric forceFlush triggered (stale)
+DEBUG io.avaje.metrics.otel - OTLP metric forceFlush completed elapsedMs:585
+```
+
+If `waitIfRunning()` had to wait for an in-flight tick:
+
+```
+DEBUG io.avaje.metrics.otel - Waiting up to 35000ms for in-flight OTLP metric export
+```
+
+Failures and timeouts are logged at WARN:
+
+```
+WARN  io.avaje.metrics.otel - OTLP metric export failed count:90 elapsedMs:5001 ...
+WARN  io.avaje.metrics.otel - Timed out waiting 35000ms for OpenTelemetry metric export to complete
+```
+
+---
+
+## Notes
+
+### Diagnostics
+
+- **No metrics in dashboard, no logs about exports**
+  Check the OTEL endpoint is reachable from the Lambda (VPC/security groups). The
+  handler will time out if `exportTimeout` is unset — set it explicitly to a value
+  smaller than the Lambda timeout.
+
+- **`Timed out waiting` lines**
+  Bump `WaiterBuilder.timeout(...)`. 35 seconds is a good starting point for Lambdas
+  configured with a 60-second timeout.
+
+- **Cold-start metrics arrive but warm-invocation metrics are missing**
+  The periodic reader is starved — set or shorten `flushIfStale` (default already
+  60 s with the Lambda preset).
+
+- **Multi-minute completion latencies**
+  Almost always the freeze-on-exit problem. The fix is exactly this guide.
+
+### Cold-start cost
+
+Building `MetricsOpenTelemetry` and the SDK in `static` initializer or DI factory adds
+to cold-start time. Typical cold start cost is in the order of 50-200 ms depending on
+the configured exporters.
+
+### Tradeoffs
+
+- `flushIfStale` adds a synchronous export to the **first invocation after cold
+  start** (because `lastSuccessAtMillis` starts at 0). This is usually desirable —
+  startup metrics ship promptly — but it does add a few hundred ms to the first
+  warm-up invocation. Pass `Duration.ZERO` to disable.
+- `connectTimeout` and `exportTimeout` are passed through to the default OTLP
+  HTTP/gRPC exporters only. They have no effect when a custom exporter is supplied
+  via `metricExporter(...)` or `spanExporter(...)`.
+- `TelemetryWaiter.noop()` is safe to use as a fallback when OTEL is disabled — it
+  performs no waiting and no flushing.

--- a/metrics-otel/README.md
+++ b/metrics-otel/README.md
@@ -183,10 +183,22 @@ current recording span.
 
 AWS Lambda freezes the worker between invocations, which can interrupt an in-flight OTLP
 HTTP/gRPC export and cause data loss. Use `enableWaitIfRunning()` to obtain a
-`TelemetryWaiter` that, at the end of an invocation, blocks briefly only if a scheduled
-background export is currently in progress. Background reporting via `PeriodicMetricReader`
-and `BatchSpanProcessor` continues on its normal schedule — this does **not** trigger an
-extra export per invocation.
+`TelemetryWaiter` that, at the end of an invocation:
+
+1. blocks briefly if a scheduled background export is currently in progress, and
+2. force-flushes telemetry that has gone stale (no successful background export within
+   the configured `flushIfStale` window).
+
+Calling `enableWaitIfRunning()` switches two defaults to Lambda-friendly values, but
+only when the caller has not already set them explicitly:
+
+- `meterInterval` → 30 seconds (default is 60 seconds for non-Lambda usage)
+- `flushIfStale` → `2 × meterInterval` (60 seconds with the default interval)
+
+In busy environments the periodic reader keeps `lastSuccess` fresh and the stale
+forceFlush is a no-op. In low-traffic environments (e.g. a Lambda invoked once a
+minute, where the periodic reader is frozen between invocations) the stale forceFlush
+ships data on the invocation thread before the runtime is suspended again.
 
 ```java
 import io.avaje.metrics.otel.MetricsOpenTelemetry;
@@ -199,11 +211,12 @@ MetricsOpenTelemetry.Result result = MetricsOpenTelemetry.builder()
     .protocol(MetricsOpenTelemetry.Protocol.HTTP_PROTOBUF)
     .endpoint("http://otel-collector:4318")
     .serviceName("orders-lambda")
-    .exportTimeout(Duration.ofSeconds(30))
-    .connectTimeout(Duration.ofSeconds(10))
+    .exportTimeout(Duration.ofSeconds(5))
+    .connectTimeout(Duration.ofSeconds(2))
     .enableWaitIfRunning()
-    .timeout(5, TimeUnit.SECONDS)
-    .buildAndRegisterGlobal();
+        .timeout(35, TimeUnit.SECONDS)
+        // .flushIfStale(Duration.ofSeconds(60))  // optional, defaults to 2 × meterInterval
+        .buildAndRegisterGlobal();
 
 OpenTelemetrySdk sdk = result.sdk();
 TelemetryWaiter waiter = result.waiter();
@@ -217,6 +230,9 @@ public void handle(Event event) {
   }
 }
 ```
+
+Pass `Duration.ZERO` to `flushIfStale(...)` to disable the stale forceFlush and use only
+the in-flight wait behaviour.
 
 `connectTimeout` and `exportTimeout` are passed through to the default OTLP HTTP/gRPC
 exporters. They have no effect when a custom exporter is supplied via

--- a/metrics-otel/README.md
+++ b/metrics-otel/README.md
@@ -179,8 +179,53 @@ recording span is current. Child traced timers then follow that root sampling de
 `@Timed(span = Timed.SpanMode.CHILD)` and `buildTraced()` remain no-op when there is no
 current recording span.
 
+#### waitIfRunning at end of invocation
+
+AWS Lambda freezes the worker between invocations, which can interrupt an in-flight OTLP
+HTTP/gRPC export and cause data loss. Use `enableWaitIfRunning()` to obtain a
+`TelemetryWaiter` that, at the end of an invocation, blocks briefly only if a scheduled
+background export is currently in progress. Background reporting via `PeriodicMetricReader`
+and `BatchSpanProcessor` continues on its normal schedule — this does **not** trigger an
+extra export per invocation.
+
+```java
+import io.avaje.metrics.otel.MetricsOpenTelemetry;
+import io.avaje.metrics.otel.TelemetryWaiter;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+MetricsOpenTelemetry.Result result = MetricsOpenTelemetry.builder()
+    .protocol(MetricsOpenTelemetry.Protocol.HTTP_PROTOBUF)
+    .endpoint("http://otel-collector:4318")
+    .serviceName("orders-lambda")
+    .exportTimeout(Duration.ofSeconds(30))
+    .connectTimeout(Duration.ofSeconds(10))
+    .enableWaitIfRunning()
+    .timeout(5, TimeUnit.SECONDS)
+    .buildAndRegisterGlobal();
+
+OpenTelemetrySdk sdk = result.sdk();
+TelemetryWaiter waiter = result.waiter();
+
+// In the Lambda handler:
+public void handle(Event event) {
+  try {
+    process(event);
+  } finally {
+    waiter.waitIfRunning();
+  }
+}
+```
+
+`connectTimeout` and `exportTimeout` are passed through to the default OTLP HTTP/gRPC
+exporters. They have no effect when a custom exporter is supplied via
+`metricExporter(...)` or `spanExporter(...)`.
+
+#### Custom exporters
+
 You can also provide custom exporters when you need OTLP-specific configuration such as headers,
-signal-specific endpoints, headers, compression, or timeouts:
+signal-specific endpoints, compression, or timeouts:
 
 ```java
 OpenTelemetrySdk sdk =

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/MetricsOpenTelemetry.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/MetricsOpenTelemetry.java
@@ -26,6 +26,7 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import static java.util.Objects.requireNonNull;
 
@@ -111,6 +112,8 @@ public final class MetricsOpenTelemetry {
     private SpanExporter spanExporter;
     private Sampler sampler;
     private Double traceSampleRatio;
+    private Duration connectTimeout;
+    private Duration exportTimeout;
 
     /**
      * Set the OTLP endpoint used for both metrics and traces.
@@ -367,6 +370,53 @@ public final class MetricsOpenTelemetry {
     }
 
     /**
+     * Set the OTLP exporter connect timeout applied to the default metric and span exporters.
+     *
+     * <p>Has no effect on exporters supplied via {@link #metricExporter(MetricExporter)} or
+     * {@link #spanExporter(SpanExporter)}.
+     *
+     * @param connectTimeout the connect timeout
+     * @return this builder
+     */
+    public Builder connectTimeout(Duration connectTimeout) {
+      this.connectTimeout = requireNonNull(connectTimeout);
+      return this;
+    }
+
+    /**
+     * Set the OTLP exporter request timeout applied to the default metric and span exporters.
+     *
+     * <p>This is the total time allowed for an export request including the response.
+     * Has no effect on exporters supplied via {@link #metricExporter(MetricExporter)} or
+     * {@link #spanExporter(SpanExporter)}.
+     *
+     * @param exportTimeout the export request timeout
+     * @return this builder
+     */
+    public Builder exportTimeout(Duration exportTimeout) {
+      this.exportTimeout = requireNonNull(exportTimeout);
+      return this;
+    }
+
+    /**
+     * Enable the {@code waitIfRunning} pattern for use with AWS Lambda or similar
+     * "freeze-on-exit" runtimes.
+     *
+     * <p>The metric and span exporters are wrapped to track in-flight exports.
+     * Background reporting continues on its normal schedule (no per-invocation flush);
+     * the returned {@link TelemetryWaiter} blocks at the end of an invocation only if a
+     * scheduled background export is currently in progress.
+     *
+     * <p>This is the last call before {@code build()} - the returned {@link WaiterBuilder}
+     * exposes only the build methods.
+     *
+     * @return a builder that produces an SDK paired with a {@link TelemetryWaiter}
+     */
+    public WaiterBuilder enableWaitIfRunning() {
+      return new WaiterBuilder(this);
+    }
+
+    /**
      * Build and return an {@link OpenTelemetrySdk}.
      *
      * @return the built SDK
@@ -492,36 +542,156 @@ public final class MetricsOpenTelemetry {
         .build();
     }
 
-    private MetricExporter metricExporter() {
+    MetricExporter metricExporter() {
       if (metricExporter != null) {
         return metricExporter;
       }
       if (protocol == Protocol.HTTP_PROTOBUF) {
-        return OtlpHttpMetricExporter.builder()
-          .setEndpoint(metricExporterEndpoint())
-          .build();
+        var b = OtlpHttpMetricExporter.builder()
+          .setEndpoint(metricExporterEndpoint());
+        if (connectTimeout != null) b.setConnectTimeout(connectTimeout);
+        if (exportTimeout != null) b.setTimeout(exportTimeout);
+        return b.build();
       }
-      return OtlpGrpcMetricExporter.builder()
-        .setEndpoint(metricExporterEndpoint())
-        .build();
+      var b = OtlpGrpcMetricExporter.builder()
+        .setEndpoint(metricExporterEndpoint());
+      if (connectTimeout != null) b.setConnectTimeout(connectTimeout);
+      if (exportTimeout != null) b.setTimeout(exportTimeout);
+      return b.build();
     }
 
-    private SpanExporter spanExporter() {
+    SpanExporter spanExporter() {
       if (spanExporter != null) {
         return spanExporter;
       }
       if (protocol == Protocol.HTTP_PROTOBUF) {
-        return OtlpHttpSpanExporter.builder()
-          .setEndpoint(spanExporterEndpoint())
-          .build();
+        var b = OtlpHttpSpanExporter.builder()
+          .setEndpoint(spanExporterEndpoint());
+        if (connectTimeout != null) b.setConnectTimeout(connectTimeout);
+        if (exportTimeout != null) b.setTimeout(exportTimeout);
+        return b.build();
       }
-      return OtlpGrpcSpanExporter.builder()
-        .setEndpoint(spanExporterEndpoint())
-        .build();
+      var b = OtlpGrpcSpanExporter.builder()
+        .setEndpoint(spanExporterEndpoint());
+      if (connectTimeout != null) b.setConnectTimeout(connectTimeout);
+      if (exportTimeout != null) b.setTimeout(exportTimeout);
+      return b.build();
+    }
+
+    boolean includeMeter() {
+      return includeMeter;
+    }
+
+    boolean includeTrace() {
+      return includeTrace;
+    }
+
+    void setMetricExporterField(MetricExporter exporter) {
+      this.metricExporter = exporter;
+    }
+
+    void setSpanExporterField(SpanExporter exporter) {
+      this.spanExporter = exporter;
     }
 
     private String endpoint() {
       return endpoint != null ? endpoint : protocol.defaultEndpoint();
+    }
+  }
+
+  /**
+   * Result of building an SDK with {@link Builder#enableWaitIfRunning()}, pairing the
+   * {@link OpenTelemetrySdk} with a {@link TelemetryWaiter} that can be used at the end
+   * of a Lambda invocation to wait for any in-flight background export to complete.
+   */
+  public static final class Result {
+
+    private final OpenTelemetrySdk sdk;
+    private final TelemetryWaiter waiter;
+
+    Result(OpenTelemetrySdk sdk, TelemetryWaiter waiter) {
+      this.sdk = sdk;
+      this.waiter = waiter;
+    }
+
+    /** The built OpenTelemetry SDK. */
+    public OpenTelemetrySdk sdk() {
+      return sdk;
+    }
+
+    /** The waiter coordinating in-flight exports. */
+    public TelemetryWaiter waiter() {
+      return waiter;
+    }
+  }
+
+  /**
+   * Builder produced by {@link Builder#enableWaitIfRunning()} that builds an
+   * {@link OpenTelemetrySdk} together with a {@link TelemetryWaiter}.
+   *
+   * <p>The configured (or default) metric and span exporters are wrapped so the
+   * waiter can observe in-flight background exports without triggering an additional
+   * export. Background reporting continues on its normal schedule.
+   */
+  public static final class WaiterBuilder {
+
+    private static final long DEFAULT_TIMEOUT_MILLIS = 5_000L;
+
+    private final Builder builder;
+    private long timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+
+    WaiterBuilder(Builder builder) {
+      this.builder = builder;
+    }
+
+    /**
+     * Set the default timeout used by {@link TelemetryWaiter#waitIfRunning()}.
+     *
+     * <p>Default is 5 seconds. The timeout applies independently per signal
+     * (metrics, traces).
+     *
+     * @param timeout the wait timeout
+     * @param unit the time unit
+     * @return this builder
+     */
+    public WaiterBuilder timeout(long timeout, TimeUnit unit) {
+      this.timeoutMillis = unit.toMillis(timeout);
+      return this;
+    }
+
+    /**
+     * Build the {@link OpenTelemetrySdk} paired with a {@link TelemetryWaiter}.
+     *
+     * @return the result containing both the SDK and the waiter
+     */
+    public Result build() {
+      var pair = wrap();
+      return new Result(builder.build(), pair);
+    }
+
+    /**
+     * Build the SDK, register it as the global OpenTelemetry instance, and return it
+     * paired with a {@link TelemetryWaiter}.
+     *
+     * @return the result containing both the SDK and the waiter
+     */
+    public Result buildAndRegisterGlobal() {
+      var pair = wrap();
+      return new Result(builder.buildAndRegisterGlobal(), pair);
+    }
+
+    private TelemetryWaiter wrap() {
+      WaitingMetricExporter waitingMetric = null;
+      WaitingSpanExporter waitingSpan = null;
+      if (builder.includeMeter()) {
+        waitingMetric = new WaitingMetricExporter(builder.metricExporter());
+        builder.setMetricExporterField(waitingMetric);
+      }
+      if (builder.includeTrace()) {
+        waitingSpan = new WaitingSpanExporter(builder.spanExporter());
+        builder.setSpanExporterField(waitingSpan);
+      }
+      return new TelemetryWaiter(waitingMetric, waitingSpan, timeoutMillis);
     }
   }
 }

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/MetricsOpenTelemetry.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/MetricsOpenTelemetry.java
@@ -91,6 +91,7 @@ public final class MetricsOpenTelemetry {
 
     private static final String DEFAULT_SCOPE = "io.avaje.metrics";
     private static final Duration DEFAULT_METER_INTERVAL = Duration.ofSeconds(60);
+    private static final Duration DEFAULT_METER_INTERVAL_LAMBDA = Duration.ofSeconds(30);
     private static final Duration DEFAULT_TRACE_INTERVAL = Duration.ofSeconds(10);
     private static final AttributeKey<String> SERVICE_NAME = AttributeKey.stringKey("service.name");
     private static final String METRICS_PATH = "/v1/metrics";
@@ -102,8 +103,8 @@ public final class MetricsOpenTelemetry {
     private String endpoint;
     private String serviceName;
     private long timedThresholdMicros;
-    private Duration meterInterval = DEFAULT_METER_INTERVAL;
-    private Duration traceInterval = DEFAULT_TRACE_INTERVAL;
+    private Duration meterInterval;
+    private Duration traceInterval;
     private MetricRegistry registry;
     private final Map<String, String> resourceAttributes = new LinkedHashMap<>();
     private ContextPropagators propagators = ContextPropagators.create(W3CTraceContextPropagator.getInstance());
@@ -408,7 +409,15 @@ public final class MetricsOpenTelemetry {
      * scheduled background export is currently in progress.
      *
      * <p>This is the last call before {@code build()} - the returned {@link WaiterBuilder}
-     * exposes only the build methods.
+     * exposes only the build methods, {@link WaiterBuilder#timeout(long, TimeUnit)} and
+     * {@link WaiterBuilder#flushIfStale(Duration)}.
+     *
+     * <p>Calling this method also flips two defaults to Lambda-friendly values, but only
+     * when the caller has not already set them explicitly:
+     * <ul>
+     *   <li>{@code meterInterval} → 30 seconds (was 60 seconds)</li>
+     *   <li>{@code flushIfStale} → {@code 2 × meterInterval} (so 60 seconds by default)</li>
+     * </ul>
      *
      * @return a builder that produces an SDK paired with a {@link TelemetryWaiter}
      */
@@ -422,6 +431,7 @@ public final class MetricsOpenTelemetry {
      * @return the built SDK
      */
     public OpenTelemetrySdk build() {
+      resolveIntervals(false);
       return sdkBuilder().build();
     }
 
@@ -431,7 +441,21 @@ public final class MetricsOpenTelemetry {
      * @return the built and globally registered SDK
      */
     public OpenTelemetrySdk buildAndRegisterGlobal() {
+      resolveIntervals(false);
       return sdkBuilder().buildAndRegisterGlobal();
+    }
+
+    /**
+     * Apply default intervals (Lambda-friendly when {@code waiting}, otherwise standard)
+     * for any interval the caller has not explicitly set.
+     */
+    void resolveIntervals(boolean waiting) {
+      if (meterInterval == null) {
+        meterInterval = waiting ? DEFAULT_METER_INTERVAL_LAMBDA : DEFAULT_METER_INTERVAL;
+      }
+      if (traceInterval == null) {
+        traceInterval = DEFAULT_TRACE_INTERVAL;
+      }
     }
 
     Builder metricReader(MetricReader metricReader) {
@@ -586,6 +610,10 @@ public final class MetricsOpenTelemetry {
       return includeTrace;
     }
 
+    Duration meterInterval() {
+      return meterInterval;
+    }
+
     void setMetricExporterField(MetricExporter exporter) {
       this.metricExporter = exporter;
     }
@@ -639,6 +667,7 @@ public final class MetricsOpenTelemetry {
 
     private final Builder builder;
     private long timeoutMillis = DEFAULT_TIMEOUT_MILLIS;
+    private Duration flushIfStale;
 
     WaiterBuilder(Builder builder) {
       this.builder = builder;
@@ -648,7 +677,7 @@ public final class MetricsOpenTelemetry {
      * Set the default timeout used by {@link TelemetryWaiter#waitIfRunning()}.
      *
      * <p>Default is 5 seconds. The timeout applies independently per signal
-     * (metrics, traces).
+     * (metrics, traces) and to any subsequent stale {@code forceFlush()}.
      *
      * @param timeout the wait timeout
      * @param unit the time unit
@@ -660,13 +689,34 @@ public final class MetricsOpenTelemetry {
     }
 
     /**
+     * Set the stale threshold that triggers a synchronous {@code forceFlush()} at the end
+     * of {@link TelemetryWaiter#waitIfRunning()} when no successful background export has
+     * completed within the threshold.
+     *
+     * <p>This is intended for low-traffic Lambda environments where the periodic metric
+     * reader is frozen between invocations and may not tick before the runtime is
+     * suspended again. In busy environments {@code lastSuccess} stays fresh and
+     * forceFlush is a no-op.
+     *
+     * <p>Default is {@code 2 × meterInterval}, so a healthy reader keeps {@code lastSuccess}
+     * younger than the threshold; one missed tick is tolerated; two or more missed ticks
+     * trigger a flush. Pass {@link Duration#ZERO} to disable.
+     *
+     * @param flushIfStale the stale threshold
+     * @return this builder
+     */
+    public WaiterBuilder flushIfStale(Duration flushIfStale) {
+      this.flushIfStale = requireNonNull(flushIfStale);
+      return this;
+    }
+
+    /**
      * Build the {@link OpenTelemetrySdk} paired with a {@link TelemetryWaiter}.
      *
      * @return the result containing both the SDK and the waiter
      */
     public Result build() {
-      var pair = wrap();
-      return new Result(builder.build(), pair);
+      return buildResult(false);
     }
 
     /**
@@ -676,11 +726,11 @@ public final class MetricsOpenTelemetry {
      * @return the result containing both the SDK and the waiter
      */
     public Result buildAndRegisterGlobal() {
-      var pair = wrap();
-      return new Result(builder.buildAndRegisterGlobal(), pair);
+      return buildResult(true);
     }
 
-    private TelemetryWaiter wrap() {
+    private Result buildResult(boolean registerGlobal) {
+      builder.resolveIntervals(true);
       WaitingMetricExporter waitingMetric = null;
       WaitingSpanExporter waitingSpan = null;
       if (builder.includeMeter()) {
@@ -691,7 +741,16 @@ public final class MetricsOpenTelemetry {
         waitingSpan = new WaitingSpanExporter(builder.spanExporter());
         builder.setSpanExporterField(waitingSpan);
       }
-      return new TelemetryWaiter(waitingMetric, waitingSpan, timeoutMillis);
+      var sdk = registerGlobal ? builder.buildAndRegisterGlobal() : builder.build();
+      var waiter = new TelemetryWaiter(waitingMetric, waitingSpan, sdk, timeoutMillis, effectiveFlushIfStale());
+      return new Result(sdk, waiter);
+    }
+
+    private Duration effectiveFlushIfStale() {
+      if (flushIfStale != null) {
+        return flushIfStale;
+      }
+      return builder.meterInterval().multipliedBy(2);
     }
   }
 }

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/TelemetryWaiter.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/TelemetryWaiter.java
@@ -1,12 +1,17 @@
 package io.avaje.metrics.otel;
 
 import io.avaje.applog.AppLog;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.trace.SdkTracerProvider;
 
 import java.lang.System.Logger.Level;
+import java.time.Duration;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Waits for any in-flight OpenTelemetry metric or span export to complete.
+ * Waits for any in-flight OpenTelemetry metric or span export to complete and,
+ * optionally, force-flushes telemetry that has gone stale.
  *
  * <p>Intended for use at the end of an AWS Lambda invocation (or similar
  * "freeze-on-exit" runtime) so that telemetry produced during the invocation
@@ -14,10 +19,14 @@ import java.util.concurrent.TimeUnit;
  * StatsD {@code waitIfRunning()} pattern: most invocations have zero overhead;
  * only an invocation that overlaps an active background export waits briefly.
  *
- * <p>This does <strong>not</strong> trigger an export. Background reporting
- * via the {@link io.opentelemetry.sdk.metrics.export.PeriodicMetricReader} and
- * {@link io.opentelemetry.sdk.trace.export.BatchSpanProcessor} continues on its
- * normal schedule.
+ * <p>If a {@code flushIfStale} duration is configured (see
+ * {@link MetricsOpenTelemetry.WaiterBuilder#flushIfStale(Duration)}), the
+ * waiter additionally triggers a {@code forceFlush()} on the SDK meter and
+ * tracer providers when no successful export has completed within that
+ * window. This makes the pattern adaptive: in busy runtimes the periodic
+ * reader keeps {@code lastSuccess} fresh and forceFlush is a no-op; in low-
+ * traffic runtimes (where the periodic reader is frozen between invocations)
+ * forceFlush ships data on the invocation thread before the runtime freezes.
  *
  * <p>Obtain an instance via {@link MetricsOpenTelemetry.Builder#enableWaitIfRunning()}.
  */
@@ -25,23 +34,31 @@ public final class TelemetryWaiter {
 
   private static final System.Logger log = AppLog.getLogger("io.avaje.metrics.otel");
 
-  private static final TelemetryWaiter NOOP = new TelemetryWaiter(null, null, 0L);
+  private static final TelemetryWaiter NOOP = new TelemetryWaiter(null, null, null, 0L, Duration.ZERO);
 
   private final WaitingMetricExporter metricExporter;
   private final WaitingSpanExporter spanExporter;
+  private final SdkMeterProvider meterProvider;
+  private final SdkTracerProvider tracerProvider;
   private final long defaultTimeoutMillis;
+  private final long flushIfStaleMillis;
 
   TelemetryWaiter(WaitingMetricExporter metricExporter,
                   WaitingSpanExporter spanExporter,
-                  long defaultTimeoutMillis) {
+                  OpenTelemetrySdk sdk,
+                  long defaultTimeoutMillis,
+                  Duration flushIfStale) {
     this.metricExporter = metricExporter;
     this.spanExporter = spanExporter;
+    this.meterProvider = sdk == null ? null : sdk.getSdkMeterProvider();
+    this.tracerProvider = sdk == null ? null : sdk.getSdkTracerProvider();
     this.defaultTimeoutMillis = defaultTimeoutMillis;
+    this.flushIfStaleMillis = flushIfStale == null ? 0L : Math.max(0L, flushIfStale.toMillis());
   }
 
   /**
-   * A no-op waiter that performs no waiting. Useful as a default when
-   * waitIfRunning has not been enabled.
+   * A no-op waiter that performs no waiting and no flushing. Useful as a
+   * default when waitIfRunning has not been enabled.
    */
   public static TelemetryWaiter noop() {
     return NOOP;
@@ -49,7 +66,9 @@ public final class TelemetryWaiter {
 
   /**
    * Wait for any in-flight metric and span exports to complete using the
-   * configured default timeout (per signal).
+   * configured default timeout (per signal). Then, if {@code flushIfStale}
+   * was configured and no successful export has completed within that
+   * window, trigger a {@code forceFlush()} on the SDK providers.
    */
   public void waitIfRunning() {
     waitIfRunning(defaultTimeoutMillis, TimeUnit.MILLISECONDS);
@@ -57,7 +76,8 @@ public final class TelemetryWaiter {
 
   /**
    * Wait for any in-flight metric and span exports to complete, applying the
-   * given timeout to each signal independently.
+   * given timeout to each signal independently. The same timeout is used for
+   * any subsequent stale {@code forceFlush()}.
    */
   public void waitIfRunning(long timeout, TimeUnit unit) {
     long timeoutMillis = unit.toMillis(timeout);
@@ -66,6 +86,47 @@ public final class TelemetryWaiter {
     }
     if (spanExporter != null && !spanExporter.waitIfRunning(timeoutMillis)) {
       log.log(Level.WARNING, "Timed out waiting " + timeoutMillis + "ms for OpenTelemetry span export to complete");
+    }
+    flushIfStale(timeoutMillis);
+  }
+
+  /**
+   * If a stale threshold is configured and the last successful export is
+   * older than that threshold (or no export has succeeded yet), force-flush
+   * the meter and tracer providers. Runs after {@link #waitIfRunning()} so
+   * an in-flight tick that has just succeeded will have already updated
+   * {@code lastSuccess}, making this a no-op.
+   */
+  private void flushIfStale(long timeoutMillis) {
+    if (flushIfStaleMillis <= 0L) {
+      return;
+    }
+    long now = System.currentTimeMillis();
+    if (meterProvider != null && metricExporter != null
+      && (now - metricExporter.lastSuccessAtMillis()) > flushIfStaleMillis) {
+      long startNanos = System.nanoTime();
+      log.log(Level.DEBUG, "OTLP metric forceFlush triggered (stale)");
+      var result = meterProvider.forceFlush();
+      result.join(timeoutMillis, TimeUnit.MILLISECONDS);
+      long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+      if (result.isSuccess()) {
+        log.log(Level.DEBUG, "OTLP metric forceFlush completed elapsedMs:{0}", elapsedMs);
+      } else {
+        log.log(Level.WARNING, "OTLP metric forceFlush did not complete elapsedMs:" + elapsedMs);
+      }
+    }
+    if (tracerProvider != null && spanExporter != null
+      && (now - spanExporter.lastSuccessAtMillis()) > flushIfStaleMillis) {
+      long startNanos = System.nanoTime();
+      log.log(Level.DEBUG, "OTLP span forceFlush triggered (stale)");
+      var result = tracerProvider.forceFlush();
+      result.join(timeoutMillis, TimeUnit.MILLISECONDS);
+      long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+      if (result.isSuccess()) {
+        log.log(Level.DEBUG, "OTLP span forceFlush completed elapsedMs:{0}", elapsedMs);
+      } else {
+        log.log(Level.WARNING, "OTLP span forceFlush did not complete elapsedMs:" + elapsedMs);
+      }
     }
   }
 }

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/TelemetryWaiter.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/TelemetryWaiter.java
@@ -1,0 +1,71 @@
+package io.avaje.metrics.otel;
+
+import io.avaje.applog.AppLog;
+
+import java.lang.System.Logger.Level;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Waits for any in-flight OpenTelemetry metric or span export to complete.
+ *
+ * <p>Intended for use at the end of an AWS Lambda invocation (or similar
+ * "freeze-on-exit" runtime) so that telemetry produced during the invocation
+ * is delivered before the process is suspended. Mirrors the avaje-metrics
+ * StatsD {@code waitIfRunning()} pattern: most invocations have zero overhead;
+ * only an invocation that overlaps an active background export waits briefly.
+ *
+ * <p>This does <strong>not</strong> trigger an export. Background reporting
+ * via the {@link io.opentelemetry.sdk.metrics.export.PeriodicMetricReader} and
+ * {@link io.opentelemetry.sdk.trace.export.BatchSpanProcessor} continues on its
+ * normal schedule.
+ *
+ * <p>Obtain an instance via {@link MetricsOpenTelemetry.Builder#enableWaitIfRunning()}.
+ */
+public final class TelemetryWaiter {
+
+  private static final System.Logger log = AppLog.getLogger("io.avaje.metrics.otel");
+
+  private static final TelemetryWaiter NOOP = new TelemetryWaiter(null, null, 0L);
+
+  private final WaitingMetricExporter metricExporter;
+  private final WaitingSpanExporter spanExporter;
+  private final long defaultTimeoutMillis;
+
+  TelemetryWaiter(WaitingMetricExporter metricExporter,
+                  WaitingSpanExporter spanExporter,
+                  long defaultTimeoutMillis) {
+    this.metricExporter = metricExporter;
+    this.spanExporter = spanExporter;
+    this.defaultTimeoutMillis = defaultTimeoutMillis;
+  }
+
+  /**
+   * A no-op waiter that performs no waiting. Useful as a default when
+   * waitIfRunning has not been enabled.
+   */
+  public static TelemetryWaiter noop() {
+    return NOOP;
+  }
+
+  /**
+   * Wait for any in-flight metric and span exports to complete using the
+   * configured default timeout (per signal).
+   */
+  public void waitIfRunning() {
+    waitIfRunning(defaultTimeoutMillis, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Wait for any in-flight metric and span exports to complete, applying the
+   * given timeout to each signal independently.
+   */
+  public void waitIfRunning(long timeout, TimeUnit unit) {
+    long timeoutMillis = unit.toMillis(timeout);
+    if (metricExporter != null && !metricExporter.waitIfRunning(timeoutMillis)) {
+      log.log(Level.WARNING, "Timed out waiting " + timeoutMillis + "ms for OpenTelemetry metric export to complete");
+    }
+    if (spanExporter != null && !spanExporter.waitIfRunning(timeoutMillis)) {
+      log.log(Level.WARNING, "Timed out waiting " + timeoutMillis + "ms for OpenTelemetry span export to complete");
+    }
+  }
+}

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/WaitingMetricExporter.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/WaitingMetricExporter.java
@@ -31,9 +31,18 @@ final class WaitingMetricExporter implements MetricExporter {
 
   private final MetricExporter delegate;
   private volatile CompletableResultCode latestExport = CompletableResultCode.ofSuccess();
+  private volatile long lastSuccessAtMillis;
 
   WaitingMetricExporter(MetricExporter delegate) {
     this.delegate = requireNonNull(delegate, "delegate");
+  }
+
+  /**
+   * The epoch milliseconds of the most recent successful export, or {@code 0}
+   * if no successful export has completed yet.
+   */
+  long lastSuccessAtMillis() {
+    return lastSuccessAtMillis;
   }
 
   @Override
@@ -46,6 +55,7 @@ final class WaitingMetricExporter implements MetricExporter {
     result.whenComplete(() -> {
       long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
       if (result.isSuccess()) {
+        lastSuccessAtMillis = System.currentTimeMillis();
         log.log(Level.DEBUG, "OTLP metric export completed count:{0} elapsedMs:{1}", count, elapsedMs);
       } else {
         log.log(Level.WARNING, "OTLP metric export failed count:" + count

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/WaitingMetricExporter.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/WaitingMetricExporter.java
@@ -1,0 +1,95 @@
+package io.avaje.metrics.otel;
+
+import io.avaje.applog.AppLog;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.common.export.MemoryMode;
+import io.opentelemetry.sdk.metrics.Aggregation;
+import io.opentelemetry.sdk.metrics.InstrumentType;
+import io.opentelemetry.sdk.metrics.data.AggregationTemporality;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+
+import java.lang.System.Logger.Level;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Wraps a {@link MetricExporter} to track the latest in-flight export so that
+ * a Lambda invocation can wait for an active background export to complete
+ * before returning.
+ *
+ * <p>Mirrors the avaje-metrics StatsD {@code waitIfRunning()} pattern: most
+ * invocations see no in-flight export and return immediately; occasionally
+ * an invocation waits briefly while a scheduled background export finishes.
+ * No additional export is triggered per invocation.
+ */
+final class WaitingMetricExporter implements MetricExporter {
+
+  private static final System.Logger log = AppLog.getLogger("io.avaje.metrics.otel");
+
+  private final MetricExporter delegate;
+  private volatile CompletableResultCode latestExport = CompletableResultCode.ofSuccess();
+
+  WaitingMetricExporter(MetricExporter delegate) {
+    this.delegate = requireNonNull(delegate, "delegate");
+  }
+
+  @Override
+  public CompletableResultCode export(Collection<MetricData> metrics) {
+    long startNanos = System.nanoTime();
+    int count = metrics.size();
+    log.log(Level.DEBUG, "OTLP metric export starting count:{0}", count);
+    var result = delegate.export(metrics);
+    latestExport = result;
+    result.whenComplete(() -> {
+      long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+      if (result.isSuccess()) {
+        log.log(Level.DEBUG, "OTLP metric export completed count:{0} elapsedMs:{1}", count, elapsedMs);
+      } else {
+        log.log(Level.WARNING, "OTLP metric export failed count:" + count
+          + " elapsedMs:" + elapsedMs, result.getFailureThrowable());
+      }
+    });
+    return result;
+  }
+
+  @Override
+  public CompletableResultCode flush() {
+    return delegate.flush();
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    return delegate.shutdown();
+  }
+
+  @Override
+  public AggregationTemporality getAggregationTemporality(InstrumentType instrumentType) {
+    return delegate.getAggregationTemporality(instrumentType);
+  }
+
+  @Override
+  public Aggregation getDefaultAggregation(InstrumentType instrumentType) {
+    return delegate.getDefaultAggregation(instrumentType);
+  }
+
+  @Override
+  public MemoryMode getMemoryMode() {
+    return delegate.getMemoryMode();
+  }
+
+  /**
+   * Block until the latest export completes or the timeout elapses.
+   * @return true if no export was active or the export completed in time
+   */
+  boolean waitIfRunning(long timeoutMillis) {
+    var current = latestExport;
+    if (current.isDone()) {
+      return true;
+    }
+    log.log(Level.DEBUG, "Waiting up to {0}ms for in-flight OTLP metric export", timeoutMillis);
+    return current.join(timeoutMillis, TimeUnit.MILLISECONDS).isDone();
+  }
+}

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/WaitingSpanExporter.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/WaitingSpanExporter.java
@@ -24,9 +24,18 @@ final class WaitingSpanExporter implements SpanExporter {
 
   private final SpanExporter delegate;
   private volatile CompletableResultCode latestExport = CompletableResultCode.ofSuccess();
+  private volatile long lastSuccessAtMillis;
 
   WaitingSpanExporter(SpanExporter delegate) {
     this.delegate = requireNonNull(delegate, "delegate");
+  }
+
+  /**
+   * The epoch milliseconds of the most recent successful export, or {@code 0}
+   * if no successful export has completed yet.
+   */
+  long lastSuccessAtMillis() {
+    return lastSuccessAtMillis;
   }
 
   @Override
@@ -39,6 +48,7 @@ final class WaitingSpanExporter implements SpanExporter {
     result.whenComplete(() -> {
       long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
       if (result.isSuccess()) {
+        lastSuccessAtMillis = System.currentTimeMillis();
         log.log(Level.DEBUG, "OTLP span export completed count:{0} elapsedMs:{1}", count, elapsedMs);
       } else {
         log.log(Level.WARNING, "OTLP span export failed count:" + count

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/WaitingSpanExporter.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/WaitingSpanExporter.java
@@ -1,0 +1,73 @@
+package io.avaje.metrics.otel;
+
+import io.avaje.applog.AppLog;
+import io.opentelemetry.sdk.common.CompletableResultCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+
+import java.lang.System.Logger.Level;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Wraps a {@link SpanExporter} to track the latest in-flight export so that
+ * a Lambda invocation can wait for an active background export to complete
+ * before returning.
+ *
+ * <p>See {@link WaitingMetricExporter} for the pattern rationale.
+ */
+final class WaitingSpanExporter implements SpanExporter {
+
+  private static final System.Logger log = AppLog.getLogger("io.avaje.metrics.otel");
+
+  private final SpanExporter delegate;
+  private volatile CompletableResultCode latestExport = CompletableResultCode.ofSuccess();
+
+  WaitingSpanExporter(SpanExporter delegate) {
+    this.delegate = requireNonNull(delegate, "delegate");
+  }
+
+  @Override
+  public CompletableResultCode export(Collection<SpanData> spans) {
+    long startNanos = System.nanoTime();
+    int count = spans.size();
+    log.log(Level.DEBUG, "OTLP span export starting count:{0}", count);
+    var result = delegate.export(spans);
+    latestExport = result;
+    result.whenComplete(() -> {
+      long elapsedMs = (System.nanoTime() - startNanos) / 1_000_000L;
+      if (result.isSuccess()) {
+        log.log(Level.DEBUG, "OTLP span export completed count:{0} elapsedMs:{1}", count, elapsedMs);
+      } else {
+        log.log(Level.WARNING, "OTLP span export failed count:" + count
+          + " elapsedMs:" + elapsedMs, result.getFailureThrowable());
+      }
+    });
+    return result;
+  }
+
+  @Override
+  public CompletableResultCode flush() {
+    return delegate.flush();
+  }
+
+  @Override
+  public CompletableResultCode shutdown() {
+    return delegate.shutdown();
+  }
+
+  /**
+   * Block until the latest export completes or the timeout elapses.
+   * @return true if no export was active or the export completed in time
+   */
+  boolean waitIfRunning(long timeoutMillis) {
+    var current = latestExport;
+    if (current.isDone()) {
+      return true;
+    }
+    log.log(Level.DEBUG, "Waiting up to {0}ms for in-flight OTLP span export", timeoutMillis);
+    return current.join(timeoutMillis, TimeUnit.MILLISECONDS).isDone();
+  }
+}

--- a/metrics-otel/src/test/java/io/avaje/metrics/otel/MetricsOpenTelemetryTest.java
+++ b/metrics-otel/src/test/java/io/avaje/metrics/otel/MetricsOpenTelemetryTest.java
@@ -20,6 +20,7 @@ import io.opentelemetry.sdk.trace.samplers.Sampler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -616,6 +617,83 @@ class MetricsOpenTelemetryTest {
     try (var sdk = result.sdk()) {
       assertThat(sdk).isNotNull();
       result.waiter().waitIfRunning();
+    }
+  }
+
+  @Test
+  void enableWaitIfRunning_defaultFlushIfStale_firesOnFirstInvocation() {
+    var metricExporter = new CapturingMetricExporter();
+    var spanExporter = InMemorySpanExporter.create();
+    var registry = Metrics.createRegistry();
+
+    var result = MetricsOpenTelemetry.builder()
+      .serviceName("catalog-service")
+      .registry(registry)
+      .metricExporter(metricExporter)
+      .spanExporter(spanExporter)
+      .enableWaitIfRunning()
+      .timeout(2, TimeUnit.SECONDS)
+      .build();
+
+    try (var sdk = result.sdk()) {
+      registry.counter("app.requests").inc(7);
+
+      // lastSuccessAtMillis starts at 0 so default flushIfStale (= 2 * meterInterval)
+      // is exceeded => waitIfRunning() triggers a synchronous forceFlush.
+      result.waiter().waitIfRunning();
+
+      assertThat(byName(metricExporter.exportedMetrics())).containsKey("app.requests");
+    }
+  }
+
+  @Test
+  void enableWaitIfRunning_flushIfStaleDisabled_doesNotForceFlush() {
+    var metricExporter = new CapturingMetricExporter();
+    var registry = Metrics.createRegistry();
+
+    var result = MetricsOpenTelemetry.builder()
+      .serviceName("catalog-service")
+      .includeTrace(false)
+      .registry(registry)
+      .metricExporter(metricExporter)
+      .meterInterval(Duration.ofMinutes(30))
+      .enableWaitIfRunning()
+      .timeout(2, TimeUnit.SECONDS)
+      .flushIfStale(Duration.ZERO)
+      .build();
+
+    try (var sdk = result.sdk()) {
+      registry.counter("app.requests").inc(7);
+
+      result.waiter().waitIfRunning();
+
+      assertThat(metricExporter.exportedMetrics()).isEmpty();
+    }
+  }
+
+  @Test
+  void enableWaitIfRunning_explicitFlushIfStaleZero_overridesDerivedDefault() {
+    var metricExporter = new CapturingMetricExporter();
+    var registry = Metrics.createRegistry();
+
+    // No explicit meterInterval => enableWaitIfRunning() flips it to 30s and
+    // would otherwise default flushIfStale to 60s (which would fire because
+    // lastSuccess starts at 0). Passing ZERO must disable that.
+    var result = MetricsOpenTelemetry.builder()
+      .serviceName("catalog-service")
+      .includeTrace(false)
+      .registry(registry)
+      .metricExporter(metricExporter)
+      .enableWaitIfRunning()
+      .flushIfStale(Duration.ZERO)
+      .build();
+
+    try (var sdk = result.sdk()) {
+      registry.counter("app.requests").inc(1);
+
+      result.waiter().waitIfRunning();
+
+      assertThat(metricExporter.exportedMetrics()).isEmpty();
     }
   }
 

--- a/metrics-otel/src/test/java/io/avaje/metrics/otel/MetricsOpenTelemetryTest.java
+++ b/metrics-otel/src/test/java/io/avaje/metrics/otel/MetricsOpenTelemetryTest.java
@@ -573,6 +573,58 @@ class MetricsOpenTelemetryTest {
     }
   }
 
+  @Test
+  void enableWaitIfRunning_buildsResultWithSdkAndWaiter() {
+    var metricExporter = new CapturingMetricExporter();
+    var spanExporter = InMemorySpanExporter.create();
+    var registry = Metrics.createRegistry();
+
+    var result = MetricsOpenTelemetry.builder()
+      .serviceName("catalog-service")
+      .registry(registry)
+      .metricExporter(metricExporter)
+      .spanExporter(spanExporter)
+      .enableWaitIfRunning()
+      .timeout(2, TimeUnit.SECONDS)
+      .build();
+
+    try (var sdk = result.sdk()) {
+      assertThat(result.waiter()).isNotNull();
+
+      registry.counter("app.requests").inc(3);
+      flush(sdk.getSdkMeterProvider().forceFlush());
+
+      assertThat(byName(metricExporter.exportedMetrics())).containsKey("app.requests");
+
+      // No in-flight export => returns immediately without exception
+      result.waiter().waitIfRunning();
+      result.waiter().waitIfRunning(100, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  @Test
+  void enableWaitIfRunning_includeMeterFalse_waiterStillUsable() {
+    var spanExporter = InMemorySpanExporter.create();
+
+    var result = MetricsOpenTelemetry.builder()
+      .serviceName("catalog-service")
+      .includeMeter(false)
+      .spanExporter(spanExporter)
+      .enableWaitIfRunning()
+      .build();
+
+    try (var sdk = result.sdk()) {
+      assertThat(sdk).isNotNull();
+      result.waiter().waitIfRunning();
+    }
+  }
+
+  @Test
+  void noopWaiter_doesNothing() {
+    TelemetryWaiter.noop().waitIfRunning();
+    TelemetryWaiter.noop().waitIfRunning(50, TimeUnit.MILLISECONDS);
+  }
+
   private static void flush(CompletableResultCode resultCode) {
     resultCode.join(5, TimeUnit.SECONDS);
     assertThat(resultCode.isSuccess()).isTrue();


### PR DESCRIPTION
With Lambda we don't really want to report on EVERY invocation as
that adds cost to every invocation. Instead we prefer to report
in background but when we do this we want to ensure that if
reporting is currently active that the reporting completes. That
is on each invocation we can call the waitIfRunning() to allow
in flight reporting to complete.