### PR TITLE
[open telemetry] Support standard OpenTelemetry SDK env vars + ScheduledTask.noop() + WaiterBuilder.timeout(Duration)

### DIFF
--- a/docs/guides/AGENTS.md
+++ b/docs/guides/AGENTS.md
@@ -17,6 +17,7 @@ Key guides (fetch and follow when performing the relevant task):
 - Add method timing: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-method-timing.md
 - Configure metrics enhancement: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/configure-metrics-agent.md
 - Add OpenTelemetry export: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-open-telemetry-export.md
+- Configure OpenTelemetry environment variables: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/configure-otel-environment.md
 - Add Prometheus scraping: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-prometheus-scrape.md
 - Add StatsD reporting: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-statsd-reporting.md
 - Add Graphite reporting: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-graphite-reporting.md

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -47,6 +47,7 @@ Step-by-step guides written as instructions for AI agents and developers working
 |-------|-------------|
 | [Add OpenTelemetry export](add-open-telemetry-export.md) | Choose between `avaje-metrics-otel`, `avaje-metrics-otel-producer`, `avaje-metrics-otel-trace`, and `avaje-metrics-otel-reporter` and wire the right OTEL path |
 | [Add OpenTelemetry export — AWS Lambda](add-open-telemetry-lambda.md) | Configure `avaje-metrics-otel` for AWS Lambda using `enableWaitIfRunning()` so freeze-on-exit and low-traffic invocations do not lose metrics |
+| [Configure OpenTelemetry environment variables](configure-otel-environment.md) | Reference for `OTEL_*` environment variables and `otel.*` system properties read by `avaje-metrics-otel` (endpoint, timeouts, intervals, deployment environment name) |
 | [Add Prometheus scraping](add-prometheus-scrape.md) | Add `avaje-metrics-prometheus` and expose a pull-based Prometheus text endpoint using cumulative collection |
 | [Add StatsD reporting](add-statsd-reporting.md) | Add `avaje-metrics-statsd`, configure `StatsdReporter`, and export avaje-metrics data to StatsD / DogStatsD |
 | [Add Graphite reporting](add-graphite-reporting.md) | Add `avaje-metrics-graphite`, configure `GraphiteReporter`, and export avaje-metrics data to Graphite |
@@ -115,6 +116,7 @@ Key guides (fetch and follow when performing the relevant task):
 - Configure metrics enhancement: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/configure-metrics-agent.md
 - Add OpenTelemetry export: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-open-telemetry-export.md
 - Add OpenTelemetry export — AWS Lambda: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-open-telemetry-lambda.md
+- Configure OpenTelemetry environment variables: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/configure-otel-environment.md
 - Add Prometheus scraping: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-prometheus-scrape.md
 - Add StatsD reporting: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-statsd-reporting.md
 - Add Graphite reporting: https://raw.githubusercontent.com/avaje/avaje-metrics/HEAD/docs/guides/add-graphite-reporting.md

--- a/docs/guides/add-open-telemetry-export.md
+++ b/docs/guides/add-open-telemetry-export.md
@@ -174,6 +174,10 @@ The service name can also be supplied using the standard `otel.service.name` sys
 attributes, `otel.service.name` / `OTEL_SERVICE_NAME` override `service.name` from resource
 attributes, and `serviceName(...)` overrides all configured service names.
 
+For the full set of OTel SDK environment variables and system properties read by the
+convenience module (endpoint, timeouts, intervals, deployment environment name) see
+[Configure OpenTelemetry environment variables](configure-otel-environment.md).
+
 ### Trace sampling
 
 Without explicit sampler configuration, the OpenTelemetry SDK default is

--- a/docs/guides/add-open-telemetry-lambda.md
+++ b/docs/guides/add-open-telemetry-lambda.md
@@ -96,7 +96,7 @@ public class OrdersHandler {
         .exportTimeout(Duration.ofSeconds(5))
         .connectTimeout(Duration.ofSeconds(2))
         .enableWaitIfRunning()
-            .timeout(35, TimeUnit.SECONDS)
+            .timeout(Duration.ofSeconds(35))
             // .flushIfStale(Duration.ofSeconds(60))  // optional
             .buildAndRegisterGlobal();
 
@@ -122,6 +122,13 @@ The two critical pieces are:
 If you have multiple Lambda handler classes in the same deployment artifact (e.g. an
 event handler **and** a schedule handler), build the SDK in a shared class so all
 handlers use the same `TelemetryWaiter` instance.
+
+> **Tip:** Most of the per-environment values above (`endpoint`, `deploymentEnvironmentName`,
+> `serviceName`) can be supplied via standard OTel SDK environment variables instead of
+> explicit builder calls. See
+> [Configure OpenTelemetry environment variables](configure-otel-environment.md) — this
+> keeps the handler code identical across environments and the values configurable from
+> CloudFormation / Lambda env vars.
 
 ---
 
@@ -175,7 +182,7 @@ public class MetricsConfig {
         .serviceName("orders-lambda")
         .exportTimeout(Duration.ofSeconds(5))
         .enableWaitIfRunning()
-            .timeout(35, TimeUnit.SECONDS)
+            .timeout(Duration.ofSeconds(35))
             .buildAndRegisterGlobal();
     this.waiter = result.waiter();
     return result.sdk();

--- a/docs/guides/add-open-telemetry-lambda.md
+++ b/docs/guides/add-open-telemetry-lambda.md
@@ -156,6 +156,11 @@ triggers a forceFlush — this is intentional, and ships startup metrics promptl
 
 ## Step 4 — Wiring with dependency injection
 
+> **⚠ Ordering matters.** The `@Bean` method that returns `TelemetryWaiter` must
+> declare `OpenTelemetry` as a parameter so the DI container invokes
+> `openTelemetry()` first. Without that parameter, the waiter bean may be created
+> before the SDK is built, returning a no-op waiter that silently never flushes.
+
 ### Spring
 
 ```java
@@ -177,8 +182,8 @@ public class MetricsConfig {
   }
 
   @Bean
-  TelemetryWaiter telemetryWaiter() {
-    return waiter;   // captured above
+  TelemetryWaiter telemetryWaiter(OpenTelemetry openTelemetry) {
+    return waiter;   // captured above; OpenTelemetry param forces this to run after openTelemetry()
   }
 
   private TelemetryWaiter waiter;
@@ -208,8 +213,8 @@ public class MetricsConfig {
   }
 
   @Bean
-  TelemetryWaiter telemetryWaiter() {
-    return waiter;
+  TelemetryWaiter telemetryWaiter(OpenTelemetry openTelemetry) {
+    return waiter;   // OpenTelemetry param forces this to run after openTelemetry()
   }
 }
 ```

--- a/docs/guides/configure-otel-environment.md
+++ b/docs/guides/configure-otel-environment.md
@@ -1,0 +1,151 @@
+# Guide: Configure OpenTelemetry environment variables
+
+## Purpose
+
+This guide is the **reference for environment variables and system properties** read by
+`avaje-metrics-otel` when configuring exporters, intervals, timeouts, and resource
+attributes.
+
+When asked to *"configure OTel via env vars"*, *"set the OTLP endpoint without code"*,
+*"deploy avaje-metrics OTel with environment-specific settings"*, or *"use standard
+OpenTelemetry environment variables"*, follow this guide.
+
+For end-to-end setup of the SDK itself, see:
+
+- [Add OpenTelemetry export](add-open-telemetry-export.md)
+- [Add OpenTelemetry export — AWS Lambda](add-open-telemetry-lambda.md)
+
+---
+
+## When to use environment variables vs builder calls
+
+Prefer environment variables (or system properties) when a value:
+
+- changes per deployment environment (TEST / PROD endpoint, deployment.environment.name)
+- is operationally tunable (export intervals, timeouts) and you do not want a code change
+  to adjust it
+- follows the OpenTelemetry specification convention (`OTEL_*`) so it can be set the same
+  way for any other OTel-enabled component in the same process
+
+Prefer explicit builder calls when a value:
+
+- is part of the application's identity and should not vary (e.g. `service.namespace`,
+  business domain attributes)
+- is not exposed by the OTel SDK env var convention
+
+In all cases, **explicit builder calls override environment variables**.
+
+---
+
+## Precedence
+
+For each value:
+
+1. Explicit `Builder` method (e.g. `.endpoint(...)`, `.meterInterval(...)`)
+2. System property (e.g. `-Dotel.exporter.otlp.endpoint=...`)
+3. Environment variable (e.g. `OTEL_EXPORTER_OTLP_ENDPOINT=...`)
+4. Built-in default
+
+The first non-blank value wins. Values found in the OTel SDK conventional env vars are
+read once at SDK build time.
+
+---
+
+## Reference
+
+### Resource attributes
+
+| Variable | System property | Purpose |
+|---|---|---|
+| `OTEL_SERVICE_NAME` | `otel.service.name` | Sets `service.name` resource attribute. Overrides `service.name` set via `OTEL_RESOURCE_ATTRIBUTES`. |
+| `OTEL_RESOURCE_ATTRIBUTES` | `otel.resource.attributes` | Comma-separated `key=value` resource attributes (URL-decoded). Merged with `Resource.getDefault()`. |
+| `OTEL_DEPLOYMENT_ENVIRONMENT_NAME` | `otel.deployment.environment.name` | Sets the `deployment.environment.name` resource attribute as a dedicated convenience env var. Overrides any value supplied via `OTEL_RESOURCE_ATTRIBUTES`. Overridden by an explicit `.deploymentEnvironmentName(...)` or `.resourceAttribute("deployment.environment.name", ...)` builder call. |
+
+`OTEL_DEPLOYMENT_ENVIRONMENT_NAME` is useful in Infrastructure-as-Code (CloudFormation,
+Terraform) setups where most resource attributes are static across environments but
+`deployment.environment.name` is computed per stack.
+
+### OTLP exporter
+
+| Variable | System property | Purpose |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | `otel.exporter.otlp.endpoint` | OTLP collector endpoint. Used when `Builder.endpoint(...)` is not set. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | `otel.exporter.otlp.protocol` | OTLP wire protocol. Recognised values: `grpc`, `http/protobuf`. Used when `Builder.protocol(...)` is not set. Default is `grpc`. The value `http/json` is rejected. |
+| `OTEL_EXPORTER_OTLP_TIMEOUT` | `otel.exporter.otlp.timeout` | Per-export timeout in **milliseconds** (per the OTel spec). Applies to both connect and request timeouts when `Builder.connectTimeout(...)` / `Builder.exportTimeout(...)` are not set. |
+
+### Intervals
+
+| Variable | System property | Purpose |
+|---|---|---|
+| `OTEL_METRIC_EXPORT_INTERVAL` | `otel.metric.export.interval` | Periodic metric reader interval in **milliseconds**. Used when `Builder.meterInterval(...)` is not set. |
+| `OTEL_BSP_SCHEDULE_DELAY` | `otel.bsp.schedule.delay` | Batch span processor schedule delay in **milliseconds**. Used when `Builder.traceInterval(...)` is not set. |
+
+### Trace sampling
+
+| Variable | System property | Purpose |
+|---|---|---|
+| `OTEL_TRACES_SAMPLER` | `otel.traces.sampler` | One of `parentbased_traceidratio`, `always_on`, `always_off`. |
+| `OTEL_TRACES_SAMPLER_ARG` | `otel.traces.sampler.arg` | Numeric ratio (0.0–1.0) for `parentbased_traceidratio`. |
+
+See [Add OpenTelemetry export](add-open-telemetry-export.md) for sampler details.
+
+---
+
+## Worked example: AWS Lambda CloudFormation
+
+Code stays minimal:
+
+```java
+var result = MetricsOpenTelemetry.builder()
+  .resourceAttribute("service.namespace", "consolidation")
+  .enableWaitIfRunning()
+  .timeout(Duration.ofSeconds(35))
+  .buildAndRegisterGlobal();
+```
+
+Configuration is supplied per environment via Lambda env vars:
+
+```yaml
+Environment:
+  Variables:
+    OTEL_SERVICE_NAME: my-lambda
+    OTEL_EXPORTER_OTLP_ENDPOINT: !Ref OtelEndpoint
+    OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
+    OTEL_DEPLOYMENT_ENVIRONMENT_NAME: !Ref Environment
+    OTEL_RESOURCE_ATTRIBUTES: !Ref OtelResourceAttributes
+    OTEL_TRACES_SAMPLER: parentbased_traceidratio
+    OTEL_TRACES_SAMPLER_ARG: !Ref OtelTraceSampleRatio
+```
+
+Where `OtelResourceAttributes` is a static, environment-agnostic set such as
+`business.domain=ingestion,business.platform=aws,business.system=consolidation`.
+
+---
+
+## Verification
+
+To confirm a setting was picked up, log the resolved attributes once at startup or
+inspect the `Resource` on a captured metric/span. For example:
+
+```java
+var sdk = MetricsOpenTelemetry.builder().buildAndRegisterGlobal();
+// Force a flush and inspect collector logs / Tempo / Mimir for resource attributes.
+```
+
+Common pitfalls:
+
+- `OTEL_*_INTERVAL` / `OTEL_*_DELAY` / `OTEL_EXPORTER_OTLP_TIMEOUT` are in **milliseconds**.
+  Setting `60` means 60ms, not 60s.
+- The OTel gateway may silently drop signals missing required resource attributes. Verify
+  the full set of `service.namespace`, `business.*`, and `deployment.environment.name` is
+  present on the `Resource` of an emitted metric.
+- An explicit `Builder.endpoint(...)` call overrides `OTEL_EXPORTER_OTLP_ENDPOINT`. Remove
+  the builder call if you want the env var to take effect.
+
+---
+
+## See also
+
+- [Add OpenTelemetry export](add-open-telemetry-export.md)
+- [Add OpenTelemetry export — AWS Lambda](add-open-telemetry-lambda.md)
+- [OpenTelemetry SDK environment variable specification](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/)

--- a/metrics-ebean/pom.xml
+++ b/metrics-ebean/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.13</version>
+    <version>9.14</version>
   </parent>
 
   <artifactId>avaje-metrics-ebean</artifactId>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.13</version>
+      <version>9.14</version>
       <scope>provided</scope>
     </dependency>
 

--- a/metrics-ebean/pom.xml
+++ b/metrics-ebean/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.12</version>
+    <version>9.13</version>
   </parent>
 
   <artifactId>avaje-metrics-ebean</artifactId>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.12</version>
+      <version>9.13</version>
       <scope>provided</scope>
     </dependency>
 

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.13</version>
+    <version>9.14</version>
   </parent>
 
   <artifactId>avaje-metrics-graphite</artifactId>
   <name>avaje-metrics-graphite</name>
-  <version>9.13</version>
+  <version>9.14</version>
 
   <properties>
     <surefire.useModulePath>false</surefire.useModulePath>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.13</version>
+      <version>9.14</version>
     </dependency>
 
     <dependency>

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.12</version>
+    <version>9.13</version>
   </parent>
 
   <artifactId>avaje-metrics-graphite</artifactId>
   <name>avaje-metrics-graphite</name>
-  <version>9.12</version>
+  <version>9.13</version>
 
   <properties>
     <surefire.useModulePath>false</surefire.useModulePath>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.12</version>
+      <version>9.13</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-producer/pom.xml
+++ b/metrics-otel-producer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.12</version>
+    <version>9.13</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-producer</artifactId>
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.12</version>
+      <version>9.13</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-producer/pom.xml
+++ b/metrics-otel-producer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.13</version>
+    <version>9.14</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-producer</artifactId>
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.13</version>
+      <version>9.14</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-reporter/pom.xml
+++ b/metrics-otel-reporter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.12</version>
+    <version>9.13</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-reporter</artifactId>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.12</version>
+      <version>9.13</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-reporter/pom.xml
+++ b/metrics-otel-reporter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.13</version>
+    <version>9.14</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-reporter</artifactId>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.13</version>
+      <version>9.14</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-trace/pom.xml
+++ b/metrics-otel-trace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.12</version>
+    <version>9.13</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-trace</artifactId>
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.12</version>
+      <version>9.13</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-trace/pom.xml
+++ b/metrics-otel-trace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.13</version>
+    <version>9.14</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-trace</artifactId>
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.13</version>
+      <version>9.14</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel/README.md
+++ b/metrics-otel/README.md
@@ -108,6 +108,14 @@ Explicit builder resource attributes override configured resource attributes, `o
 `OTEL_SERVICE_NAME` override `service.name` from resource attributes, and `serviceName(...)`
 overrides all configured service names.
 
+The endpoint, protocol, intervals, timeouts, and `deployment.environment.name` can also be supplied via
+standard OpenTelemetry SDK environment variables (`OTEL_EXPORTER_OTLP_ENDPOINT`,
+`OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_TIMEOUT`, `OTEL_METRIC_EXPORT_INTERVAL`,
+`OTEL_BSP_SCHEDULE_DELAY`, `OTEL_DEPLOYMENT_ENVIRONMENT_NAME`) and equivalent `otel.*` system
+properties. See
+[Configure OpenTelemetry environment variables](../docs/guides/configure-otel-environment.md)
+for the full reference and precedence rules.
+
 ## Trace sampling
 
 If no sampler is configured, the OpenTelemetry SDK default applies:
@@ -205,7 +213,6 @@ import io.avaje.metrics.otel.MetricsOpenTelemetry;
 import io.avaje.metrics.otel.TelemetryWaiter;
 
 import java.time.Duration;
-import java.util.concurrent.TimeUnit;
 
 MetricsOpenTelemetry.Result result = MetricsOpenTelemetry.builder()
     .protocol(MetricsOpenTelemetry.Protocol.HTTP_PROTOBUF)
@@ -214,7 +221,7 @@ MetricsOpenTelemetry.Result result = MetricsOpenTelemetry.builder()
     .exportTimeout(Duration.ofSeconds(5))
     .connectTimeout(Duration.ofSeconds(2))
     .enableWaitIfRunning()
-        .timeout(35, TimeUnit.SECONDS)
+        .timeout(Duration.ofSeconds(35))
         // .flushIfStale(Duration.ofSeconds(60))  // optional, defaults to 2 × meterInterval
         .buildAndRegisterGlobal();
 

--- a/metrics-otel/pom.xml
+++ b/metrics-otel/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.12</version>
+    <version>9.13</version>
   </parent>
 
   <artifactId>avaje-metrics-otel</artifactId>
@@ -20,19 +20,19 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.12</version>
+      <version>9.13</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics-otel-producer</artifactId>
-      <version>9.12</version>
+      <version>9.13</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics-otel-trace</artifactId>
-      <version>9.12</version>
+      <version>9.13</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel/pom.xml
+++ b/metrics-otel/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.13</version>
+    <version>9.14</version>
   </parent>
 
   <artifactId>avaje-metrics-otel</artifactId>
@@ -20,19 +20,19 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.13</version>
+      <version>9.14</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics-otel-producer</artifactId>
-      <version>9.13</version>
+      <version>9.14</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics-otel-trace</artifactId>
-      <version>9.13</version>
+      <version>9.14</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/MetricsOpenTelemetry.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/MetricsOpenTelemetry.java
@@ -99,7 +99,7 @@ public final class MetricsOpenTelemetry {
 
     private boolean includeTrace = true;
     private boolean includeMeter = true;
-    private Protocol protocol = Protocol.GRPC;
+    private Protocol protocol;
     private String endpoint;
     private String serviceName;
     private long timedThresholdMicros;
@@ -137,7 +137,10 @@ public final class MetricsOpenTelemetry {
     /**
      * Set the OTLP exporter protocol.
      *
-     * <p>Default is {@link Protocol#GRPC}. For signal-specific exporter configuration, use
+     * <p>If not set, the protocol is resolved from the {@code OTEL_EXPORTER_OTLP_PROTOCOL}
+     * environment variable / {@code otel.exporter.otlp.protocol} system property
+     * (recognised values: {@code grpc}, {@code http/protobuf}), defaulting to
+     * {@link Protocol#GRPC}. For signal-specific exporter configuration, use
      * {@link #metricExporter(MetricExporter)} and {@link #spanExporter(SpanExporter)}.
      *
      * @param protocol the OTLP exporter protocol
@@ -409,7 +412,7 @@ public final class MetricsOpenTelemetry {
      * scheduled background export is currently in progress.
      *
      * <p>This is the last call before {@code build()} - the returned {@link WaiterBuilder}
-     * exposes only the build methods, {@link WaiterBuilder#timeout(long, TimeUnit)} and
+     * exposes only the build methods, {@link WaiterBuilder#timeout(Duration)} and
      * {@link WaiterBuilder#flushIfStale(Duration)}.
      *
      * <p>Calling this method also flips two defaults to Lambda-friendly values, but only
@@ -447,14 +450,30 @@ public final class MetricsOpenTelemetry {
 
     /**
      * Apply default intervals (Lambda-friendly when {@code waiting}, otherwise standard)
-     * for any interval the caller has not explicitly set.
+     * and timeouts for any value the caller has not explicitly set, falling back through
+     * standard OpenTelemetry SDK environment variables and system properties before applying
+     * built-in defaults.
      */
     void resolveIntervals(boolean waiting) {
+      protocol();
+      if (meterInterval == null) {
+        meterInterval = OtelEnv.metricExportInterval();
+      }
       if (meterInterval == null) {
         meterInterval = waiting ? DEFAULT_METER_INTERVAL_LAMBDA : DEFAULT_METER_INTERVAL;
       }
       if (traceInterval == null) {
+        traceInterval = OtelEnv.bspScheduleDelay();
+      }
+      if (traceInterval == null) {
         traceInterval = DEFAULT_TRACE_INTERVAL;
+      }
+      var otlpTimeout = (connectTimeout == null || exportTimeout == null) ? OtelEnv.otlpTimeout() : null;
+      if (connectTimeout == null && otlpTimeout != null) {
+        connectTimeout = otlpTimeout;
+      }
+      if (exportTimeout == null && otlpTimeout != null) {
+        exportTimeout = otlpTimeout;
       }
     }
 
@@ -464,14 +483,14 @@ public final class MetricsOpenTelemetry {
     }
 
     String metricExporterEndpoint() {
-      if (protocol == Protocol.HTTP_PROTOBUF) {
+      if (protocol() == Protocol.HTTP_PROTOBUF) {
         return otlpHttpEndpoint(endpoint(), METRICS_PATH);
       }
       return endpoint();
     }
 
     String spanExporterEndpoint() {
-      if (protocol == Protocol.HTTP_PROTOBUF) {
+      if (protocol() == Protocol.HTTP_PROTOBUF) {
         return otlpHttpEndpoint(endpoint(), TRACES_PATH);
       }
       return endpoint();
@@ -501,6 +520,10 @@ public final class MetricsOpenTelemetry {
     private Resource resource() {
       var attributes = new LinkedHashMap<String, String>();
       attributes.putAll(ResourceAttributes.configuredAttributes());
+      var configuredDeploymentEnv = OtelEnv.deploymentEnvironmentName();
+      if (configuredDeploymentEnv != null) {
+        attributes.put(ResourceAttributes.DEPLOYMENT_ENVIRONMENT_NAME, configuredDeploymentEnv);
+      }
       attributes.putAll(resourceAttributes);
       var resource = Resource.getDefault();
       if (!attributes.isEmpty()) {
@@ -570,7 +593,7 @@ public final class MetricsOpenTelemetry {
       if (metricExporter != null) {
         return metricExporter;
       }
-      if (protocol == Protocol.HTTP_PROTOBUF) {
+      if (protocol() == Protocol.HTTP_PROTOBUF) {
         var b = OtlpHttpMetricExporter.builder()
           .setEndpoint(metricExporterEndpoint());
         if (connectTimeout != null) b.setConnectTimeout(connectTimeout);
@@ -588,7 +611,7 @@ public final class MetricsOpenTelemetry {
       if (spanExporter != null) {
         return spanExporter;
       }
-      if (protocol == Protocol.HTTP_PROTOBUF) {
+      if (protocol() == Protocol.HTTP_PROTOBUF) {
         var b = OtlpHttpSpanExporter.builder()
           .setEndpoint(spanExporterEndpoint());
         if (connectTimeout != null) b.setConnectTimeout(connectTimeout);
@@ -614,6 +637,26 @@ public final class MetricsOpenTelemetry {
       return meterInterval;
     }
 
+    Protocol protocol() {
+      if (protocol == null) {
+        var configuredProtocol = OtelEnv.otlpProtocol();
+        protocol = configuredProtocol != null ? configuredProtocol : Protocol.GRPC;
+      }
+      return protocol;
+    }
+
+    Duration traceInterval() {
+      return traceInterval;
+    }
+
+    Duration connectTimeout() {
+      return connectTimeout;
+    }
+
+    Duration exportTimeout() {
+      return exportTimeout;
+    }
+
     void setMetricExporterField(MetricExporter exporter) {
       this.metricExporter = exporter;
     }
@@ -623,7 +666,11 @@ public final class MetricsOpenTelemetry {
     }
 
     private String endpoint() {
-      return endpoint != null ? endpoint : protocol.defaultEndpoint();
+      if (endpoint != null) {
+        return endpoint;
+      }
+      var configured = OtelEnv.otlpEndpoint();
+      return configured != null ? configured : protocol().defaultEndpoint();
     }
   }
 
@@ -685,6 +732,20 @@ public final class MetricsOpenTelemetry {
      */
     public WaiterBuilder timeout(long timeout, TimeUnit unit) {
       this.timeoutMillis = unit.toMillis(timeout);
+      return this;
+    }
+
+    /**
+     * Set the default timeout used by {@link TelemetryWaiter#waitIfRunning()}.
+     *
+     * <p>Default is 5 seconds. The timeout applies independently per signal
+     * (metrics, traces) and to any subsequent stale {@code forceFlush()}.
+     *
+     * @param timeout the wait timeout
+     * @return this builder
+     */
+    public WaiterBuilder timeout(Duration timeout) {
+      this.timeoutMillis = requireNonNull(timeout, "timeout").toMillis();
       return this;
     }
 

--- a/metrics-otel/src/main/java/io/avaje/metrics/otel/OtelEnv.java
+++ b/metrics-otel/src/main/java/io/avaje/metrics/otel/OtelEnv.java
@@ -1,0 +1,117 @@
+package io.avaje.metrics.otel;
+
+import java.time.Duration;
+
+/**
+ * Fallback resolution of OpenTelemetry SDK standard environment variables and
+ * system properties used when builder fields are not explicitly set.
+ *
+ * <p>Resolution precedence (first non-blank wins):
+ * <ol>
+ *   <li>System property (e.g. {@code otel.exporter.otlp.endpoint})</li>
+ *   <li>Environment variable (e.g. {@code OTEL_EXPORTER_OTLP_ENDPOINT})</li>
+ * </ol>
+ *
+ * <p>For duration-valued settings, values are interpreted as milliseconds per the
+ * OTel specification.
+ */
+final class OtelEnv {
+
+  static final String OTLP_PROTOCOL_PROP = "otel.exporter.otlp.protocol";
+  static final String OTLP_PROTOCOL_ENV = "OTEL_EXPORTER_OTLP_PROTOCOL";
+
+  static final String OTLP_ENDPOINT_PROP = "otel.exporter.otlp.endpoint";
+  static final String OTLP_ENDPOINT_ENV = "OTEL_EXPORTER_OTLP_ENDPOINT";
+
+  static final String OTLP_TIMEOUT_PROP = "otel.exporter.otlp.timeout";
+  static final String OTLP_TIMEOUT_ENV = "OTEL_EXPORTER_OTLP_TIMEOUT";
+
+  static final String METRIC_EXPORT_INTERVAL_PROP = "otel.metric.export.interval";
+  static final String METRIC_EXPORT_INTERVAL_ENV = "OTEL_METRIC_EXPORT_INTERVAL";
+
+  static final String BSP_SCHEDULE_DELAY_PROP = "otel.bsp.schedule.delay";
+  static final String BSP_SCHEDULE_DELAY_ENV = "OTEL_BSP_SCHEDULE_DELAY";
+
+  static final String DEPLOYMENT_ENVIRONMENT_NAME_PROP = "otel.deployment.environment.name";
+  static final String DEPLOYMENT_ENVIRONMENT_NAME_ENV = "OTEL_DEPLOYMENT_ENVIRONMENT_NAME";
+
+  private OtelEnv() {
+  }
+
+  static String otlpEndpoint() {
+    return readString(OTLP_ENDPOINT_PROP, OTLP_ENDPOINT_ENV);
+  }
+
+  /**
+   * Read the configured OTLP exporter protocol from system property or environment
+   * variable, returning {@code null} if not configured.
+   *
+   * <p>Recognised values per the OpenTelemetry SDK specification: {@code grpc} and
+   * {@code http/protobuf}. The value {@code http/json} is rejected as it is not
+   * supported by this module.
+   */
+  static MetricsOpenTelemetry.Protocol otlpProtocol() {
+    var raw = readString(OTLP_PROTOCOL_PROP, OTLP_PROTOCOL_ENV);
+    if (raw == null) {
+      return null;
+    }
+    var lower = raw.toLowerCase();
+    if (lower.equals("grpc")) {
+      return MetricsOpenTelemetry.Protocol.GRPC;
+    }
+    if (lower.equals("http/protobuf")) {
+      return MetricsOpenTelemetry.Protocol.HTTP_PROTOBUF;
+    }
+    throw new IllegalStateException(
+      "Unsupported OTLP protocol '" + raw + "' from " + OTLP_PROTOCOL_PROP + " / "
+        + OTLP_PROTOCOL_ENV + " — supported values: grpc, http/protobuf");
+  }
+
+  static Duration otlpTimeout() {
+    return readDurationMillis(OTLP_TIMEOUT_PROP, OTLP_TIMEOUT_ENV);
+  }
+
+  static Duration metricExportInterval() {
+    return readDurationMillis(METRIC_EXPORT_INTERVAL_PROP, METRIC_EXPORT_INTERVAL_ENV);
+  }
+
+  static Duration bspScheduleDelay() {
+    return readDurationMillis(BSP_SCHEDULE_DELAY_PROP, BSP_SCHEDULE_DELAY_ENV);
+  }
+
+  static String deploymentEnvironmentName() {
+    return readString(DEPLOYMENT_ENVIRONMENT_NAME_PROP, DEPLOYMENT_ENVIRONMENT_NAME_ENV);
+  }
+
+  private static String readString(String property, String env) {
+    var value = System.getProperty(property);
+    if (hasText(value)) {
+      return value.trim();
+    }
+    value = System.getenv(env);
+    if (hasText(value)) {
+      return value.trim();
+    }
+    return null;
+  }
+
+  private static Duration readDurationMillis(String property, String env) {
+    var raw = readString(property, env);
+    if (raw == null) {
+      return null;
+    }
+    try {
+      var millis = Long.parseLong(raw);
+      if (millis <= 0) {
+        return null;
+      }
+      return Duration.ofMillis(millis);
+    } catch (NumberFormatException e) {
+      throw new IllegalStateException("Invalid duration in milliseconds for " + property + " / " + env + ": '" + raw + "'", e);
+    }
+  }
+
+  private static boolean hasText(String value) {
+    return value != null && !value.trim().isEmpty();
+  }
+}

--- a/metrics-otel/src/test/java/io/avaje/metrics/otel/MetricsOpenTelemetryTest.java
+++ b/metrics-otel/src/test/java/io/avaje/metrics/otel/MetricsOpenTelemetryTest.java
@@ -49,6 +49,12 @@ class MetricsOpenTelemetryTest {
     System.clearProperty(ResourceAttributes.SERVICE_NAME_PROPERTY);
     System.clearProperty(TraceSampling.TRACES_SAMPLER_PROPERTY);
     System.clearProperty(TraceSampling.TRACES_SAMPLER_ARG_PROPERTY);
+    System.clearProperty(OtelEnv.OTLP_ENDPOINT_PROP);
+    System.clearProperty(OtelEnv.OTLP_PROTOCOL_PROP);
+    System.clearProperty(OtelEnv.OTLP_TIMEOUT_PROP);
+    System.clearProperty(OtelEnv.METRIC_EXPORT_INTERVAL_PROP);
+    System.clearProperty(OtelEnv.BSP_SCHEDULE_DELAY_PROP);
+    System.clearProperty(OtelEnv.DEPLOYMENT_ENVIRONMENT_NAME_PROP);
   }
 
   @Test
@@ -267,6 +273,105 @@ class MetricsOpenTelemetryTest {
       assertThat(metricResource.getAttribute(DEPLOYMENT_ENVIRONMENT_NAME)).isEqualTo("staging");
       assertThat(metricResource.getAttribute(SERVICE_NAMESPACE)).isEqualTo("fleet");
     }
+  }
+
+  @Test
+  void configuredDeploymentEnvironmentName_fromSystemProperty() {
+    System.setProperty(OtelEnv.DEPLOYMENT_ENVIRONMENT_NAME_PROP, "test-env");
+    var metricReader = InMemoryMetricReader.create();
+    var registry = Metrics.createRegistry();
+
+    try (var openTelemetry = MetricsOpenTelemetry.builder()
+      .registry(registry)
+      .metricReader(metricReader)
+      .includeTrace(false)
+      .build()) {
+
+      registry.counter("app.requests").inc(1);
+
+      var metricResource = onlyMetric(metricReader.collectAllMetrics()).getResource();
+      assertThat(metricResource.getAttribute(DEPLOYMENT_ENVIRONMENT_NAME)).isEqualTo("test-env");
+    }
+  }
+
+  @Test
+  void deploymentEnvironmentName_explicit_overridesConfigured() {
+    System.setProperty(OtelEnv.DEPLOYMENT_ENVIRONMENT_NAME_PROP, "test-env");
+    var metricReader = InMemoryMetricReader.create();
+    var registry = Metrics.createRegistry();
+
+    try (var openTelemetry = MetricsOpenTelemetry.builder()
+      .deploymentEnvironmentName("production")
+      .registry(registry)
+      .metricReader(metricReader)
+      .includeTrace(false)
+      .build()) {
+
+      registry.counter("app.requests").inc(1);
+
+      var metricResource = onlyMetric(metricReader.collectAllMetrics()).getResource();
+      assertThat(metricResource.getAttribute(DEPLOYMENT_ENVIRONMENT_NAME)).isEqualTo("production");
+    }
+  }
+
+  @Test
+  void resolveIntervals_usesEnvVarsForIntervals() {
+    System.setProperty(OtelEnv.METRIC_EXPORT_INTERVAL_PROP, "45000");
+    System.setProperty(OtelEnv.BSP_SCHEDULE_DELAY_PROP, "1500");
+
+    var builder = MetricsOpenTelemetry.builder();
+    builder.resolveIntervals(false);
+
+    assertThat(builder.meterInterval()).isEqualTo(Duration.ofSeconds(45));
+    assertThat(builder.traceInterval()).isEqualTo(Duration.ofMillis(1500));
+  }
+
+  @Test
+  void resolveIntervals_usesEnvVarTimeouts_whenNotSet() {
+    System.setProperty(OtelEnv.OTLP_TIMEOUT_PROP, "20000");
+
+    var builder = MetricsOpenTelemetry.builder();
+    builder.resolveIntervals(false);
+
+    assertThat(builder.connectTimeout()).isEqualTo(Duration.ofSeconds(20));
+    assertThat(builder.exportTimeout()).isEqualTo(Duration.ofSeconds(20));
+  }
+
+  @Test
+  void resolveIntervals_explicitTimeouts_overrideEnvVar() {
+    System.setProperty(OtelEnv.OTLP_TIMEOUT_PROP, "20000");
+
+    var builder = MetricsOpenTelemetry.builder()
+      .connectTimeout(Duration.ofSeconds(7))
+      .exportTimeout(Duration.ofSeconds(8));
+    builder.resolveIntervals(false);
+
+    assertThat(builder.connectTimeout()).isEqualTo(Duration.ofSeconds(7));
+    assertThat(builder.exportTimeout()).isEqualTo(Duration.ofSeconds(8));
+  }
+
+  @Test
+  void resolveIntervals_protocolDefault_isGrpc() {
+    var builder = MetricsOpenTelemetry.builder();
+    builder.resolveIntervals(false);
+    assertThat(builder.protocol()).isEqualTo(MetricsOpenTelemetry.Protocol.GRPC);
+  }
+
+  @Test
+  void resolveIntervals_protocolFromEnvVar() {
+    System.setProperty(OtelEnv.OTLP_PROTOCOL_PROP, "http/protobuf");
+    var builder = MetricsOpenTelemetry.builder();
+    builder.resolveIntervals(false);
+    assertThat(builder.protocol()).isEqualTo(MetricsOpenTelemetry.Protocol.HTTP_PROTOBUF);
+  }
+
+  @Test
+  void resolveIntervals_explicitProtocol_overridesEnvVar() {
+    System.setProperty(OtelEnv.OTLP_PROTOCOL_PROP, "http/protobuf");
+    var builder = MetricsOpenTelemetry.builder()
+      .protocol(MetricsOpenTelemetry.Protocol.GRPC);
+    builder.resolveIntervals(false);
+    assertThat(builder.protocol()).isEqualTo(MetricsOpenTelemetry.Protocol.GRPC);
   }
 
   @Test
@@ -572,6 +677,32 @@ class MetricsOpenTelemetryTest {
     } finally {
       GlobalOpenTelemetry.resetForTest();
     }
+  }
+
+  @Test
+  void enableWaitIfRunning_timeoutDuration_overload() {
+    var registry = Metrics.createRegistry();
+    var result = MetricsOpenTelemetry.builder()
+      .registry(registry)
+      .metricExporter(new CapturingMetricExporter())
+      .spanExporter(InMemorySpanExporter.create())
+      .enableWaitIfRunning()
+      .timeout(Duration.ofMillis(750))
+      .build();
+
+    try (var sdk = result.sdk()) {
+      assertThat(result.waiter()).isNotNull();
+      result.waiter().waitIfRunning();
+    }
+  }
+
+  @Test
+  void enableWaitIfRunning_timeoutDuration_null_throws() {
+    assertThatThrownBy(() -> MetricsOpenTelemetry.builder()
+      .enableWaitIfRunning()
+      .timeout(null))
+      .isInstanceOf(NullPointerException.class)
+      .hasMessageContaining("timeout");
   }
 
   @Test

--- a/metrics-otel/src/test/java/io/avaje/metrics/otel/OtelEnvTest.java
+++ b/metrics-otel/src/test/java/io/avaje/metrics/otel/OtelEnvTest.java
@@ -1,0 +1,115 @@
+package io.avaje.metrics.otel;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OtelEnvTest {
+
+  @AfterEach
+  void tearDown() {
+    System.clearProperty(OtelEnv.OTLP_ENDPOINT_PROP);
+    System.clearProperty(OtelEnv.OTLP_PROTOCOL_PROP);
+    System.clearProperty(OtelEnv.OTLP_TIMEOUT_PROP);
+    System.clearProperty(OtelEnv.METRIC_EXPORT_INTERVAL_PROP);
+    System.clearProperty(OtelEnv.BSP_SCHEDULE_DELAY_PROP);
+    System.clearProperty(OtelEnv.DEPLOYMENT_ENVIRONMENT_NAME_PROP);
+  }
+
+  @Test
+  void otlpEndpoint_default_null() {
+    assertThat(OtelEnv.otlpEndpoint()).isNull();
+  }
+
+  @Test
+  void otlpEndpoint_fromSystemProperty() {
+    System.setProperty(OtelEnv.OTLP_ENDPOINT_PROP, "https://collector.example:4318");
+    assertThat(OtelEnv.otlpEndpoint()).isEqualTo("https://collector.example:4318");
+  }
+
+  @Test
+  void otlpEndpoint_blank_isNull() {
+    System.setProperty(OtelEnv.OTLP_ENDPOINT_PROP, "   ");
+    assertThat(OtelEnv.otlpEndpoint()).isNull();
+  }
+
+  @Test
+  void otlpEndpoint_trimmed() {
+    System.setProperty(OtelEnv.OTLP_ENDPOINT_PROP, "  https://x:4318  ");
+    assertThat(OtelEnv.otlpEndpoint()).isEqualTo("https://x:4318");
+  }
+
+  @Test
+  void otlpTimeout_default_null() {
+    assertThat(OtelEnv.otlpTimeout()).isNull();
+  }
+
+  @Test
+  void otlpTimeout_fromSystemProperty_millis() {
+    System.setProperty(OtelEnv.OTLP_TIMEOUT_PROP, "15000");
+    assertThat(OtelEnv.otlpTimeout()).isEqualTo(Duration.ofSeconds(15));
+  }
+
+  @Test
+  void otlpTimeout_zeroOrNegative_null() {
+    System.setProperty(OtelEnv.OTLP_TIMEOUT_PROP, "0");
+    assertThat(OtelEnv.otlpTimeout()).isNull();
+    System.setProperty(OtelEnv.OTLP_TIMEOUT_PROP, "-5");
+    assertThat(OtelEnv.otlpTimeout()).isNull();
+  }
+
+  @Test
+  void otlpTimeout_invalid_throws() {
+    System.setProperty(OtelEnv.OTLP_TIMEOUT_PROP, "abc");
+    assertThatThrownBy(OtelEnv::otlpTimeout)
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining(OtelEnv.OTLP_TIMEOUT_PROP);
+  }
+
+  @Test
+  void metricExportInterval_fromSystemProperty() {
+    System.setProperty(OtelEnv.METRIC_EXPORT_INTERVAL_PROP, "120000");
+    assertThat(OtelEnv.metricExportInterval()).isEqualTo(Duration.ofMinutes(2));
+  }
+
+  @Test
+  void bspScheduleDelay_fromSystemProperty() {
+    System.setProperty(OtelEnv.BSP_SCHEDULE_DELAY_PROP, "2500");
+    assertThat(OtelEnv.bspScheduleDelay()).isEqualTo(Duration.ofMillis(2500));
+  }
+
+  @Test
+  void deploymentEnvironmentName_fromSystemProperty() {
+    System.setProperty(OtelEnv.DEPLOYMENT_ENVIRONMENT_NAME_PROP, "test");
+    assertThat(OtelEnv.deploymentEnvironmentName()).isEqualTo("test");
+  }
+
+  @Test
+  void otlpProtocol_default_null() {
+    assertThat(OtelEnv.otlpProtocol()).isNull();
+  }
+
+  @Test
+  void otlpProtocol_grpc() {
+    System.setProperty(OtelEnv.OTLP_PROTOCOL_PROP, "grpc");
+    assertThat(OtelEnv.otlpProtocol()).isEqualTo(MetricsOpenTelemetry.Protocol.GRPC);
+  }
+
+  @Test
+  void otlpProtocol_httpProtobuf_caseInsensitive() {
+    System.setProperty(OtelEnv.OTLP_PROTOCOL_PROP, "HTTP/Protobuf");
+    assertThat(OtelEnv.otlpProtocol()).isEqualTo(MetricsOpenTelemetry.Protocol.HTTP_PROTOBUF);
+  }
+
+  @Test
+  void otlpProtocol_unsupported_throws() {
+    System.setProperty(OtelEnv.OTLP_PROTOCOL_PROP, "http/json");
+    assertThatThrownBy(OtelEnv::otlpProtocol)
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessageContaining("http/json");
+  }
+}

--- a/metrics-prometheus/pom.xml
+++ b/metrics-prometheus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.13</version>
+    <version>9.14</version>
   </parent>
 
   <artifactId>avaje-metrics-prometheus</artifactId>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.13</version>
+      <version>9.14</version>
     </dependency>
 
     <dependency>

--- a/metrics-prometheus/pom.xml
+++ b/metrics-prometheus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.12</version>
+    <version>9.13</version>
   </parent>
 
   <artifactId>avaje-metrics-prometheus</artifactId>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.12</version>
+      <version>9.13</version>
     </dependency>
 
     <dependency>

--- a/metrics-statsd/pom.xml
+++ b/metrics-statsd/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.12</version>
+    <version>9.13</version>
   </parent>
 
   <artifactId>avaje-metrics-statsd</artifactId>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.12</version>
+      <version>9.13</version>
     </dependency>
 
     <dependency>

--- a/metrics-statsd/pom.xml
+++ b/metrics-statsd/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.13</version>
+    <version>9.14</version>
   </parent>
 
   <artifactId>avaje-metrics-statsd</artifactId>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.13</version>
+      <version>9.14</version>
     </dependency>
 
     <dependency>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.13</version>
+    <version>9.14</version>
   </parent>
 
   <artifactId>avaje-metrics</artifactId>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.12</version>
+    <version>9.13</version>
   </parent>
 
   <artifactId>avaje-metrics</artifactId>

--- a/metrics/src/main/java/io/avaje/metrics/NoopScheduledTask.java
+++ b/metrics/src/main/java/io/avaje/metrics/NoopScheduledTask.java
@@ -1,0 +1,30 @@
+package io.avaje.metrics;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * No-op {@link ScheduledTask}. All operations are no-ops; nothing is scheduled
+ * and no executor resources are held. Returned by {@link ScheduledTask#noop()}.
+ */
+final class NoopScheduledTask implements ScheduledTask {
+
+  static final NoopScheduledTask INSTANCE = new NoopScheduledTask();
+
+  private NoopScheduledTask() {
+  }
+
+  @Override
+  public void start() {
+    // no-op
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    return false;
+  }
+
+  @Override
+  public void waitIfRunning(long timeout, TimeUnit timeUnit) {
+    // no-op
+  }
+}

--- a/metrics/src/main/java/io/avaje/metrics/ScheduledTask.java
+++ b/metrics/src/main/java/io/avaje/metrics/ScheduledTask.java
@@ -19,6 +19,17 @@ public interface ScheduledTask {
   }
 
   /**
+   * Return a no-op ScheduledTask whose {@link #start()}, {@link #cancel(boolean)}
+   * and {@link #waitIfRunning(long, TimeUnit)} methods do nothing.
+   * <p>
+   * Useful as a placeholder when a real reporter is not configured but a
+   * {@code ScheduledTask} bean is still required by DI.
+   */
+  static ScheduledTask noop() {
+    return NoopScheduledTask.INSTANCE;
+  }
+
+  /**
    * Start the scheduled task.
    */
   void start();

--- a/metrics/src/test/java/io/avaje/metrics/ScheduledTaskTest.java
+++ b/metrics/src/test/java/io/avaje/metrics/ScheduledTaskTest.java
@@ -56,6 +56,19 @@ class ScheduledTaskTest {
     System.out.println("done");
   }
 
+  @Test
+  void noop_doesNothing() {
+    var task = ScheduledTask.noop();
+    task.start();
+    task.waitIfRunning(1, TimeUnit.SECONDS);
+    assertThat(task.cancel(true)).isFalse();
+  }
+
+  @Test
+  void noop_isSingleton() {
+    assertThat(ScheduledTask.noop()).isSameAs(ScheduledTask.noop());
+  }
+
   private static final AtomicLong counter = new AtomicLong();
 
   private static void hello() {

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>io.avaje</groupId>
   <artifactId>avaje-metrics-parent</artifactId>
   <name>avaje-metrics-parent</name>
-  <version>9.13</version>
+  <version>9.14</version>
   <packaging>pom</packaging>
 
   <url>https://avaje-metrics.github.io</url>
@@ -23,7 +23,7 @@
 
   <properties>
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
-    <project.build.outputTimestamp>2026-06-03T02:35:02Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-06-03T08:20:53Z</project.build.outputTimestamp>
   </properties>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>io.avaje</groupId>
   <artifactId>avaje-metrics-parent</artifactId>
   <name>avaje-metrics-parent</name>
-  <version>9.12</version>
+  <version>9.13</version>
   <packaging>pom</packaging>
 
   <url>https://avaje-metrics.github.io</url>
@@ -23,7 +23,7 @@
 
   <properties>
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
-    <project.build.outputTimestamp>2026-05-28T11:25:59Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-06-03T02:35:02Z</project.build.outputTimestamp>
   </properties>
 
   <modules>


### PR DESCRIPTION
Adds support for configuring MetricsOpenTelemetry via standard OpenTelemetry SDK environment variables and system properties (matching the OTel spec), plus two small ergonomic improvements.

 Motivated by deploying avaje-metrics-otel to AWS Lambda where most configuration is environment-specific and best supplied via Lambda env vars rather than code.