### PR TITLE
Modify avaje-metrics-ebean to support tagged names and include datasource metrics by default

### DIFF
--- a/docs/guides/add-ebean-metrics.md
+++ b/docs/guides/add-ebean-metrics.md
@@ -54,6 +54,40 @@ Metrics.addSupplier(new DatabaseMetricSupplier(database));
 That is the core setup. After this, Ebean metrics are part of normal avaje-metrics
 collection.
 
+### Metric naming (default)
+
+The supplier emits avaje-metrics names following the label-tag convention. Ebean's flat
+internal names like `iud.BProcessLog.insertBatch` or `dto.SensorState` are mapped to a
+small set of metric names plus tags:
+
+| Ebean prefix              | Metric name   | Tags                              |
+|---------------------------|---------------|-----------------------------------|
+| `iud.X`                   | `ebean.dml`   | `label=X`                         |
+| `dto.X`                   | `ebean.query` | `type=dto, label=X`               |
+| `orm.X`                   | `ebean.query` | `type=orm, label=X`               |
+| `sql.X`                   | `ebean.query` | `type=sql, label=X`               |
+| `txn.named.X` / `txn.X`   | `ebean.txn`   | `label=X`                         |
+| `l2.<region>.<op>`        | `ebean.l2`    | `op=<op>, region=<region>`        |
+| (anything else)           | `ebean.other` | `label=<original ebean name>`     |
+
+This shape works well for tag-aware backends such as Prometheus / OTLP, where all read
+paths roll up under `ebean_query` and can be filtered by `type`.
+
+### Legacy flat names (Graphite-friendly)
+
+For hierarchical reporters such as Graphite, opt in to the legacy flat-prefixed names via
+the builder:
+
+```java
+Metrics.addSupplier(
+    DatabaseMetricSupplier.builder(database)
+        .legacyNames()
+        .build());
+```
+
+Note: `GraphiteReporter.builder().database(database)` does not go through the supplier
+and is unaffected by the default naming change.
+
 ---
 
 ## Step 3 — Collect or export the metrics
@@ -114,6 +148,9 @@ In those cases, manual supplier registration may not be necessary.
 
 - `DatabaseMetricSupplier` maps Ebean timed metrics, query metrics, and count metrics
   into avaje-metrics `TimerStats` and `CounterStats`.
+- By default, names follow the label-tag convention (`ebean.query`, `ebean.dml`,
+  `ebean.txn`, `ebean.l2`). Use `DatabaseMetricSupplier.builder(database).legacyNames()`
+  to keep Ebean's flat names (e.g. `iud.BProcessLog.insertBatch`).
 - This module is most useful when the export path is built around registry collection.
 - For reporter modules with direct `.database(...)` support, use the simpler direct path
   unless you specifically need supplier-level control.

--- a/docs/guides/add-ebean-metrics.md
+++ b/docs/guides/add-ebean-metrics.md
@@ -88,6 +88,32 @@ Metrics.addSupplier(
 Note: `GraphiteReporter.builder().database(database)` does not go through the supplier
 and is unaffected by the default naming change.
 
+### DataSourcePool metrics
+
+When the database's main and/or read-only `DataSource` is an
+`io.ebean.datasource.DataSourcePool`, the supplier additionally emits connection-pool
+metrics tagged `db=<name>, pool=main|readonly`:
+
+| Metric                  | Type     | Source on `PoolStatus`                                                |
+|-------------------------|----------|-----------------------------------------------------------------------|
+| `ebean.pool.busy`       | gauge    | `busy()` — connections currently in use                               |
+| `ebean.pool.free`       | gauge    | `free()` — connections currently idle                                 |
+| `ebean.pool.waiting`    | gauge    | `waiting()` — threads currently waiting for a connection              |
+| `ebean.pool.acquire`    | timer    | count = `hitCount`, total = `totalAcquireMicros`, max = `maxAcquireMicros` |
+| `ebean.pool.wait`       | timer    | count = `waitCount`, total = `totalWaitMicros`                        |
+
+Disable with the builder if not wanted:
+
+```java
+Metrics.addSupplier(
+    DatabaseMetricSupplier.builder(database)
+        .excludePoolMetrics()
+        .build());
+```
+
+If neither datasource is a `DataSourcePool`, no pool metrics are emitted and there is no
+runtime cost.
+
 ---
 
 ## Step 3 — Collect or export the metrics

--- a/metrics-ebean/pom.xml
+++ b/metrics-ebean/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.14</version>
+    <version>9.15</version>
   </parent>
 
   <artifactId>avaje-metrics-ebean</artifactId>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.14</version>
+      <version>9.15</version>
       <scope>provided</scope>
     </dependency>
 

--- a/metrics-ebean/pom.xml
+++ b/metrics-ebean/pom.xml
@@ -37,6 +37,13 @@
     </dependency>
 
     <dependency>
+      <groupId>io.ebean</groupId>
+      <artifactId>ebean-datasource-api</artifactId>
+      <version>10.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
       <version>1.6</version>

--- a/metrics-ebean/src/main/java/io/avaje/metrics/ebean/DatabaseMetricSupplier.java
+++ b/metrics-ebean/src/main/java/io/avaje/metrics/ebean/DatabaseMetricSupplier.java
@@ -42,6 +42,7 @@ public final class DatabaseMetricSupplier implements MetricSupplier {
 
   private final Database database;
   private final boolean legacyNames;
+  private final PoolStatsCollector poolStats;
   private final ConcurrentMap<String, Metric.ID> idCache = new ConcurrentHashMap<>();
 
   /**
@@ -49,12 +50,13 @@ public final class DatabaseMetricSupplier implements MetricSupplier {
    * for the opt-in to legacy flat-prefixed names.
    */
   public DatabaseMetricSupplier(Database database) {
-    this(database, false);
+    this(database, false, true);
   }
 
-  private DatabaseMetricSupplier(Database database, boolean legacyNames) {
+  private DatabaseMetricSupplier(Database database, boolean legacyNames, boolean includePoolMetrics) {
     this.database = Objects.requireNonNull(database, "database");
     this.legacyNames = legacyNames;
+    this.poolStats = includePoolMetrics ? new PoolStatsCollector(database) : null;
   }
 
   /**
@@ -89,6 +91,9 @@ public final class DatabaseMetricSupplier implements MetricSupplier {
     for (MetaCountMetric metric : dbMetrics.countMetrics()) {
       metrics.add(new CounterStats(idFor(metric.name()), metric.count()));
     }
+    if (poolStats != null) {
+      poolStats.collect(metrics, reset);
+    }
     return metrics;
   }
 
@@ -109,6 +114,7 @@ public final class DatabaseMetricSupplier implements MetricSupplier {
 
     private final Database database;
     private boolean legacyNames;
+    private boolean includePoolMetrics = true;
 
     Builder(Database database) {
       this.database = Objects.requireNonNull(database, "database");
@@ -123,8 +129,18 @@ public final class DatabaseMetricSupplier implements MetricSupplier {
       return this;
     }
 
+    /**
+     * Disable {@link io.ebean.datasource.DataSourcePool} metrics ({@code ebean.pool.*}).
+     * <p>By default these are collected when the database's datasource is a
+     * {@code DataSourcePool}.
+     */
+    public Builder excludePoolMetrics() {
+      this.includePoolMetrics = false;
+      return this;
+    }
+
     public DatabaseMetricSupplier build() {
-      return new DatabaseMetricSupplier(database, legacyNames);
+      return new DatabaseMetricSupplier(database, legacyNames, includePoolMetrics);
     }
   }
 }

--- a/metrics-ebean/src/main/java/io/avaje/metrics/ebean/DatabaseMetricSupplier.java
+++ b/metrics-ebean/src/main/java/io/avaje/metrics/ebean/DatabaseMetricSupplier.java
@@ -12,18 +12,56 @@ import io.ebean.meta.*;
 import java.lang.System.Logger.Level;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * Supplies Ebean metrics to avaje-metrics for reporting.
+ *
+ * <p>By default emits avaje-metrics names following the label-tag convention:
+ * <ul>
+ *   <li>{@code ebean.query} with tags {@code type=dto|orm|sql, label=<ebean label>}</li>
+ *   <li>{@code ebean.dml}   with tag  {@code label=<ebean label>}</li>
+ *   <li>{@code ebean.txn}   with tag  {@code label=<ebean label>}</li>
+ *   <li>{@code ebean.l2}    with tags {@code op=..., region=...}</li>
+ * </ul>
+ *
+ * <p>For the older flat-prefixed names (e.g. {@code iud.BProcessLog.insertBatch}) suitable
+ * for hierarchical reporters such as Graphite, opt in via {@link #builder(Database)}:
+ *
+ * <pre>{@code
+ * DatabaseMetricSupplier.builder(database)
+ *     .legacyNames()
+ *     .build();
+ * }</pre>
  */
 public final class DatabaseMetricSupplier implements MetricSupplier {
 
   private static final System.Logger log = AppLog.getLogger("io.avaje.metrics.ebean");
 
-  final Database database;
+  private final Database database;
+  private final boolean legacyNames;
+  private final ConcurrentMap<String, Metric.ID> idCache = new ConcurrentHashMap<>();
 
+  /**
+   * Construct a supplier emitting tagged avaje-metrics names. See {@link #builder(Database)}
+   * for the opt-in to legacy flat-prefixed names.
+   */
   public DatabaseMetricSupplier(Database database) {
-    this.database = database;
+    this(database, false);
+  }
+
+  private DatabaseMetricSupplier(Database database, boolean legacyNames) {
+    this.database = Objects.requireNonNull(database, "database");
+    this.legacyNames = legacyNames;
+  }
+
+  /**
+   * Builder for advanced configuration of the supplier.
+   */
+  public static Builder builder(Database database) {
+    return new Builder(database);
   }
 
   @Override
@@ -43,15 +81,50 @@ public final class DatabaseMetricSupplier implements MetricSupplier {
       log.log(Level.DEBUG, dbMetrics.asJson().withHash(false).withNewLine(false).json());
     }
     for (MetaTimedMetric timedMetric : dbMetrics.timedMetrics()) {
-      metrics.add(new TimerStats(Metric.ID.of(timedMetric.name()), timedMetric.count(), timedMetric.total(), timedMetric.max()));
+      metrics.add(new TimerStats(idFor(timedMetric.name()), timedMetric.count(), timedMetric.total(), timedMetric.max()));
     }
     for (MetaQueryMetric metric : dbMetrics.queryMetrics()) {
-      metrics.add(new TimerStats(Metric.ID.of(metric.name()), metric.count(), metric.total(), metric.max()));
+      metrics.add(new TimerStats(idFor(metric.name()), metric.count(), metric.total(), metric.max()));
     }
     for (MetaCountMetric metric : dbMetrics.countMetrics()) {
-      metrics.add(new CounterStats(Metric.ID.of(metric.name()), metric.count()));
+      metrics.add(new CounterStats(idFor(metric.name()), metric.count()));
     }
     return metrics;
   }
 
+  private Metric.ID idFor(String ebeanName) {
+    var cached = idCache.get(ebeanName);
+    if (cached != null) {
+      return cached;
+    }
+    var id = legacyNames ? Metric.ID.of(ebeanName) : EbeanMetricNaming.toId(ebeanName);
+    idCache.put(ebeanName, id);
+    return id;
+  }
+
+  /**
+   * Builder for {@link DatabaseMetricSupplier}.
+   */
+  public static final class Builder {
+
+    private final Database database;
+    private boolean legacyNames;
+
+    Builder(Database database) {
+      this.database = Objects.requireNonNull(database, "database");
+    }
+
+    /**
+     * Use the legacy flat-prefixed metric names (e.g. {@code iud.BProcessLog.insertBatch})
+     * suitable for hierarchical reporters such as Graphite.
+     */
+    public Builder legacyNames() {
+      this.legacyNames = true;
+      return this;
+    }
+
+    public DatabaseMetricSupplier build() {
+      return new DatabaseMetricSupplier(database, legacyNames);
+    }
+  }
 }

--- a/metrics-ebean/src/main/java/io/avaje/metrics/ebean/EbeanMetricNaming.java
+++ b/metrics-ebean/src/main/java/io/avaje/metrics/ebean/EbeanMetricNaming.java
@@ -1,0 +1,68 @@
+package io.avaje.metrics.ebean;
+
+import io.avaje.metrics.Metric;
+import io.avaje.metrics.Tags;
+
+/**
+ * Maps Ebean's internal flat metric names (e.g. {@code iud.BProcessLog.insertBatch},
+ * {@code dto.SensorState}, {@code orm.Organisation.findById}, {@code txn.named.MapDailyMachine.run})
+ * into avaje-metrics names with tags following the label-tag convention.
+ *
+ * <p>Mapping:
+ * <table>
+ *   <caption>Ebean prefix → avaje-metrics name + tags</caption>
+ *   <tr><th>Ebean prefix</th><th>Metric name</th><th>Tags</th></tr>
+ *   <tr><td>{@code iud.X}</td><td>{@code ebean.dml}</td><td>{@code label=X}</td></tr>
+ *   <tr><td>{@code dto.X}</td><td>{@code ebean.query}</td><td>{@code type=dto, label=X}</td></tr>
+ *   <tr><td>{@code orm.X}</td><td>{@code ebean.query}</td><td>{@code type=orm, label=X}</td></tr>
+ *   <tr><td>{@code sql.X}</td><td>{@code ebean.query}</td><td>{@code type=sql, label=X}</td></tr>
+ *   <tr><td>{@code txn.named.X} or {@code txn.X}</td><td>{@code ebean.txn}</td><td>{@code label=X}</td></tr>
+ *   <tr><td>{@code l2.<region>.<op>}</td><td>{@code ebean.l2}</td><td>{@code op=..., region=...}</td></tr>
+ *   <tr><td>(unrecognised)</td><td>{@code ebean.other}</td><td>{@code label=&lt;original name&gt;}</td></tr>
+ * </table>
+ */
+final class EbeanMetricNaming {
+
+  private EbeanMetricNaming() {
+  }
+
+  static Metric.ID toId(String ebeanName) {
+    if (ebeanName == null || ebeanName.isEmpty()) {
+      return Metric.ID.of("ebean.other");
+    }
+    int firstDot = ebeanName.indexOf('.');
+    if (firstDot <= 0) {
+      return Metric.ID.of("ebean.other", Tags.of("label:" + ebeanName));
+    }
+    var prefix = ebeanName.substring(0, firstDot);
+    var rest = ebeanName.substring(firstDot + 1);
+    switch (prefix) {
+      case "iud":
+        return Metric.ID.of("ebean.dml", Tags.of("label:" + rest));
+      case "dto":
+        return Metric.ID.of("ebean.query", Tags.of("type:dto", "label:" + rest));
+      case "orm":
+        return Metric.ID.of("ebean.query", Tags.of("type:orm", "label:" + rest));
+      case "sql":
+        return Metric.ID.of("ebean.query", Tags.of("type:sql", "label:" + rest));
+      case "txn":
+        var txnLabel = rest.startsWith("named.") ? rest.substring("named.".length()) : rest;
+        return Metric.ID.of("ebean.txn", Tags.of("label:" + txnLabel));
+      case "l2":
+        return l2Id(rest);
+      default:
+        return Metric.ID.of("ebean.other", Tags.of("label:" + ebeanName));
+    }
+  }
+
+  private static Metric.ID l2Id(String rest) {
+    // Ebean L2 names look like "l2.<region>.<op>" or "l2.<op>".
+    int dot = rest.indexOf('.');
+    if (dot <= 0) {
+      return Metric.ID.of("ebean.l2", Tags.of("op:" + rest));
+    }
+    var region = rest.substring(0, dot);
+    var op = rest.substring(dot + 1);
+    return Metric.ID.of("ebean.l2", Tags.of("op:" + op, "region:" + region));
+  }
+}

--- a/metrics-ebean/src/main/java/io/avaje/metrics/ebean/PoolStatsCollector.java
+++ b/metrics-ebean/src/main/java/io/avaje/metrics/ebean/PoolStatsCollector.java
@@ -1,0 +1,82 @@
+package io.avaje.metrics.ebean;
+
+import io.avaje.metrics.Metric;
+import io.avaje.metrics.Tags;
+import io.avaje.metrics.stats.GaugeLongStats;
+import io.avaje.metrics.stats.TimerStats;
+import io.ebean.Database;
+import io.ebean.datasource.DataSourcePool;
+import io.ebean.datasource.PoolStatus;
+
+import javax.sql.DataSource;
+import java.util.List;
+
+/**
+ * Collects {@link DataSourcePool} metrics for a {@link Database}, when its main
+ * and/or read-only datasource is a {@code DataSourcePool}.
+ *
+ * <p>Metric shape (when the corresponding pool exists):
+ * <ul>
+ *   <li>{@code ebean.pool.busy}    — gauge — connections currently in use</li>
+ *   <li>{@code ebean.pool.free}    — gauge — connections currently idle</li>
+ *   <li>{@code ebean.pool.waiting} — gauge — threads currently waiting for a connection</li>
+ *   <li>{@code ebean.pool.acquire} — timer — count = hits, total = totalAcquireMicros, max = maxAcquireMicros</li>
+ *   <li>{@code ebean.pool.wait}    — timer — count = waits, total = totalWaitMicros</li>
+ * </ul>
+ *
+ * <p>All metrics carry tags {@code db=<name>, pool=main|readonly}.
+ */
+final class PoolStatsCollector {
+
+  private final PoolEntry main;
+  private final PoolEntry readOnly;
+
+  PoolStatsCollector(Database database) {
+    var dbName = database.name();
+    DataSource ds = database.dataSource();
+    DataSource roDs = database.readOnlyDataSource();
+    this.main = (ds instanceof DataSourcePool) ? new PoolEntry((DataSourcePool) ds, dbName, "main") : null;
+    this.readOnly = (roDs instanceof DataSourcePool && roDs != ds)
+        ? new PoolEntry((DataSourcePool) roDs, dbName, "readonly")
+        : null;
+  }
+
+  boolean hasAny() {
+    return main != null || readOnly != null;
+  }
+
+  void collect(List<Metric.Statistics> out, boolean reset) {
+    if (main != null) main.collect(out, reset);
+    if (readOnly != null) readOnly.collect(out, reset);
+  }
+
+  /** Pre-built Metric.IDs and stats fetch for a single pool. */
+  private static final class PoolEntry {
+
+    private final DataSourcePool pool;
+    private final Metric.ID busyId;
+    private final Metric.ID freeId;
+    private final Metric.ID waitingId;
+    private final Metric.ID acquireId;
+    private final Metric.ID waitId;
+
+    PoolEntry(DataSourcePool pool, String db, String role) {
+      this.pool = pool;
+      var tags = Tags.of("db:" + db, "pool:" + role);
+      this.busyId = Metric.ID.of("ebean.pool.busy", tags);
+      this.freeId = Metric.ID.of("ebean.pool.free", tags);
+      this.waitingId = Metric.ID.of("ebean.pool.waiting", tags);
+      this.acquireId = Metric.ID.of("ebean.pool.acquire", tags);
+      this.waitId = Metric.ID.of("ebean.pool.wait", tags);
+    }
+
+    void collect(List<Metric.Statistics> out, boolean reset) {
+      PoolStatus status = pool.status(reset);
+      out.add(new GaugeLongStats(busyId, status.busy()));
+      out.add(new GaugeLongStats(freeId, status.free()));
+      out.add(new GaugeLongStats(waitingId, status.waiting()));
+      out.add(new TimerStats(acquireId, status.hitCount(), status.totalAcquireMicros(), status.maxAcquireMicros()));
+      out.add(new TimerStats(waitId, status.waitCount(), status.totalWaitMicros(), 0));
+    }
+  }
+}

--- a/metrics-ebean/src/test/java/io/avaje/metrics/ebean/EbeanMetricNamingTest.java
+++ b/metrics-ebean/src/test/java/io/avaje/metrics/ebean/EbeanMetricNamingTest.java
@@ -1,0 +1,92 @@
+package io.avaje.metrics.ebean;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class EbeanMetricNamingTest {
+
+  @Test
+  void iud_mapsToDml() {
+    var id = EbeanMetricNaming.toId("iud.BProcessLog.insertBatch");
+    assertThat(id.name()).isEqualTo("ebean.dml");
+    assertThat(id.tags().array()).containsExactly("label:BProcessLog.insertBatch");
+  }
+
+  @Test
+  void dto_mapsToQueryWithType() {
+    var id = EbeanMetricNaming.toId("dto.SensorState");
+    assertThat(id.name()).isEqualTo("ebean.query");
+    assertThat(id.tags().array()).containsExactly("type:dto", "label:SensorState");
+  }
+
+  @Test
+  void orm_mapsToQueryWithType() {
+    var id = EbeanMetricNaming.toId("orm.Organisation.findById");
+    assertThat(id.name()).isEqualTo("ebean.query");
+    assertThat(id.tags().array()).containsExactly("type:orm", "label:Organisation.findById");
+  }
+
+  @Test
+  void sql_mapsToQueryWithType() {
+    var id = EbeanMetricNaming.toId("sql.someRawQuery");
+    assertThat(id.name()).isEqualTo("ebean.query");
+    assertThat(id.tags().array()).containsExactly("type:sql", "label:someRawQuery");
+  }
+
+  @Test
+  void txnNamed_mapsToTxn_stripsNamedPrefix() {
+    var id = EbeanMetricNaming.toId("txn.named.MapDailyMachine.run");
+    assertThat(id.name()).isEqualTo("ebean.txn");
+    assertThat(id.tags().array()).containsExactly("label:MapDailyMachine.run");
+  }
+
+  @Test
+  void txnBare_mapsToTxn() {
+    var id = EbeanMetricNaming.toId("txn.SomeTransaction");
+    assertThat(id.name()).isEqualTo("ebean.txn");
+    assertThat(id.tags().array()).containsExactly("label:SomeTransaction");
+  }
+
+  @Test
+  void l2_withRegionAndOp() {
+    var id = EbeanMetricNaming.toId("l2.beanCache.hit");
+    assertThat(id.name()).isEqualTo("ebean.l2");
+    assertThat(id.tags().array()).containsExactly("op:hit", "region:beanCache");
+  }
+
+  @Test
+  void l2_opOnly() {
+    var id = EbeanMetricNaming.toId("l2.miss");
+    assertThat(id.name()).isEqualTo("ebean.l2");
+    assertThat(id.tags().array()).containsExactly("op:miss");
+  }
+
+  @Test
+  void unrecognised_mapsToOther_withFullLabel() {
+    var id = EbeanMetricNaming.toId("custom.thing");
+    assertThat(id.name()).isEqualTo("ebean.other");
+    assertThat(id.tags().array()).containsExactly("label:custom.thing");
+  }
+
+  @Test
+  void noPrefix_mapsToOther() {
+    var id = EbeanMetricNaming.toId("plain");
+    assertThat(id.name()).isEqualTo("ebean.other");
+    assertThat(id.tags().array()).containsExactly("label:plain");
+  }
+
+  @Test
+  void empty_mapsToOther() {
+    var id = EbeanMetricNaming.toId("");
+    assertThat(id.name()).isEqualTo("ebean.other");
+    assertThat(id.tags().isEmpty()).isTrue();
+  }
+
+  @Test
+  void nullName_mapsToOther() {
+    var id = EbeanMetricNaming.toId(null);
+    assertThat(id.name()).isEqualTo("ebean.other");
+    assertThat(id.tags().isEmpty()).isTrue();
+  }
+}

--- a/metrics-ebean/src/test/java/io/avaje/metrics/ebean/PoolStatsCollectorTest.java
+++ b/metrics-ebean/src/test/java/io/avaje/metrics/ebean/PoolStatsCollectorTest.java
@@ -1,0 +1,153 @@
+package io.avaje.metrics.ebean;
+
+import io.avaje.metrics.Metric;
+import io.avaje.metrics.stats.GaugeLongStats;
+import io.avaje.metrics.stats.TimerStats;
+import io.ebean.Database;
+import io.ebean.datasource.DataSourcePool;
+import io.ebean.datasource.PoolStatus;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class PoolStatsCollectorTest {
+
+  private static PoolStatus status(int busy, int free, int waiting,
+                                   int hits, long totalAcquireMicros,
+                                   int waits, long totalWaitMicros,
+                                   long maxAcquireMicros) {
+    var s = mock(PoolStatus.class);
+    when(s.busy()).thenReturn(busy);
+    when(s.free()).thenReturn(free);
+    when(s.waiting()).thenReturn(waiting);
+    when(s.hitCount()).thenReturn(hits);
+    when(s.totalAcquireMicros()).thenReturn(totalAcquireMicros);
+    when(s.waitCount()).thenReturn(waits);
+    when(s.totalWaitMicros()).thenReturn(totalWaitMicros);
+    when(s.maxAcquireMicros()).thenReturn(maxAcquireMicros);
+    return s;
+  }
+
+  @Test
+  void mainPoolOnly_emitsAllMetrics() {
+    var s = status(3, 7, 1, 100, 250_000L, 5, 1_000L, 8_000L);
+    var pool = mock(DataSourcePool.class);
+    when(pool.status(true)).thenReturn(s);
+
+    var db = mock(Database.class);
+    when(db.name()).thenReturn("h2");
+    when(db.dataSource()).thenReturn(pool);
+    when(db.readOnlyDataSource()).thenReturn(null);
+
+    var collector = new PoolStatsCollector(db);
+    assertThat(collector.hasAny()).isTrue();
+
+    var out = new ArrayList<Metric.Statistics>();
+    collector.collect(out, true);
+
+    assertThat(out).hasSize(5);
+
+    var byName = byName(out);
+    assertThat(((GaugeLongStats) byName.get("ebean.pool.busy")).id().tags().array())
+        .containsExactly("db:h2", "pool:main");
+
+    var acquire = (TimerStats) byName.get("ebean.pool.acquire");
+    assertThat(acquire.count()).isEqualTo(100);
+    assertThat(acquire.total()).isEqualTo(250_000L);
+    assertThat(acquire.max()).isEqualTo(8_000L);
+
+    var wait = (TimerStats) byName.get("ebean.pool.wait");
+    assertThat(wait.count()).isEqualTo(5);
+    assertThat(wait.total()).isEqualTo(1_000L);
+  }
+
+  @Test
+  void noPool_collectsNothing() {
+    var ds = mock(DataSource.class); // not a DataSourcePool
+    var db = mock(Database.class);
+    when(db.name()).thenReturn("h2");
+    when(db.dataSource()).thenReturn(ds);
+    when(db.readOnlyDataSource()).thenReturn(ds);
+
+    var collector = new PoolStatsCollector(db);
+    assertThat(collector.hasAny()).isFalse();
+
+    var out = new ArrayList<Metric.Statistics>();
+    collector.collect(out, true);
+    assertThat(out).isEmpty();
+  }
+
+  @Test
+  void samePoolForMainAndReadOnly_emitsOnce() {
+    var s = status(1, 1, 0, 1, 0L, 0, 0L, 0L);
+    var pool = mock(DataSourcePool.class);
+    when(pool.status(true)).thenReturn(s);
+
+    var db = mock(Database.class);
+    when(db.name()).thenReturn("h2");
+    when(db.dataSource()).thenReturn(pool);
+    when(db.readOnlyDataSource()).thenReturn(pool);
+
+    var out = new ArrayList<Metric.Statistics>();
+    new PoolStatsCollector(db).collect(out, true);
+
+    var roleTags = out.stream()
+        .map(stat -> stat.id().tags().array()[1])
+        .distinct()
+        .collect(java.util.stream.Collectors.toList());
+    assertThat(roleTags).containsExactly("pool:main");
+  }
+
+  @Test
+  void mainAndReadOnlyPools_bothEmitted() {
+    var s1 = status(0, 0, 0, 0, 0L, 0, 0L, 0L);
+    var s2 = status(0, 0, 0, 0, 0L, 0, 0L, 0L);
+    var mainPool = mock(DataSourcePool.class);
+    when(mainPool.status(true)).thenReturn(s1);
+    var roPool = mock(DataSourcePool.class);
+    when(roPool.status(true)).thenReturn(s2);
+
+    var db = mock(Database.class);
+    when(db.name()).thenReturn("h2");
+    when(db.dataSource()).thenReturn(mainPool);
+    when(db.readOnlyDataSource()).thenReturn(roPool);
+
+    var out = new ArrayList<Metric.Statistics>();
+    new PoolStatsCollector(db).collect(out, true);
+
+    // 5 metrics × 2 pools
+    assertThat(out).hasSize(10);
+    assertThat(out.stream().map(stat -> stat.id().tags().array()[1]).distinct()
+        .collect(java.util.stream.Collectors.toList()))
+        .containsExactlyInAnyOrder("pool:main", "pool:readonly");
+  }
+
+  @Test
+  void cumulativeMode_passesResetFalse() {
+    var s = status(0, 0, 0, 0, 0L, 0, 0L, 0L);
+    var pool = mock(DataSourcePool.class);
+    when(pool.status(false)).thenReturn(s);
+
+    var db = mock(Database.class);
+    when(db.name()).thenReturn("h2");
+    when(db.dataSource()).thenReturn(pool);
+    when(db.readOnlyDataSource()).thenReturn(null);
+
+    new PoolStatsCollector(db).collect(new ArrayList<>(), false);
+    // verified via the when(pool.status(false)) stub being matched
+  }
+
+  private static java.util.Map<String, Metric.Statistics> byName(List<Metric.Statistics> stats) {
+    var m = new java.util.HashMap<String, Metric.Statistics>();
+    for (var s : stats) {
+      m.put(s.id().name(), s);
+    }
+    return m;
+  }
+}

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.14</version>
+    <version>9.15</version>
   </parent>
 
   <artifactId>avaje-metrics-graphite</artifactId>
   <name>avaje-metrics-graphite</name>
-  <version>9.14</version>
+  <version>9.15</version>
 
   <properties>
     <surefire.useModulePath>false</surefire.useModulePath>
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.14</version>
+      <version>9.15</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-producer/pom.xml
+++ b/metrics-otel-producer/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.14</version>
+    <version>9.15</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-producer</artifactId>
@@ -20,7 +20,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.14</version>
+      <version>9.15</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-reporter/pom.xml
+++ b/metrics-otel-reporter/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.14</version>
+    <version>9.15</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-reporter</artifactId>
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.14</version>
+      <version>9.15</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel-trace/pom.xml
+++ b/metrics-otel-trace/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.14</version>
+    <version>9.15</version>
   </parent>
 
   <artifactId>avaje-metrics-otel-trace</artifactId>
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.14</version>
+      <version>9.15</version>
     </dependency>
 
     <dependency>

--- a/metrics-otel/pom.xml
+++ b/metrics-otel/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>avaje-metrics-parent</artifactId>
     <groupId>io.avaje</groupId>
-    <version>9.14</version>
+    <version>9.15</version>
   </parent>
 
   <artifactId>avaje-metrics-otel</artifactId>
@@ -20,19 +20,19 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.14</version>
+      <version>9.15</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics-otel-producer</artifactId>
-      <version>9.14</version>
+      <version>9.15</version>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics-otel-trace</artifactId>
-      <version>9.14</version>
+      <version>9.15</version>
     </dependency>
 
     <dependency>

--- a/metrics-prometheus/pom.xml
+++ b/metrics-prometheus/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.14</version>
+    <version>9.15</version>
   </parent>
 
   <artifactId>avaje-metrics-prometheus</artifactId>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.14</version>
+      <version>9.15</version>
     </dependency>
 
     <dependency>

--- a/metrics-statsd/pom.xml
+++ b/metrics-statsd/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.14</version>
+    <version>9.15</version>
   </parent>
 
   <artifactId>avaje-metrics-statsd</artifactId>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>avaje-metrics</artifactId>
-      <version>9.14</version>
+      <version>9.15</version>
     </dependency>
 
     <dependency>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>io.avaje</groupId>
     <artifactId>avaje-metrics-parent</artifactId>
-    <version>9.14</version>
+    <version>9.15</version>
   </parent>
 
   <artifactId>avaje-metrics</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <groupId>io.avaje</groupId>
   <artifactId>avaje-metrics-parent</artifactId>
   <name>avaje-metrics-parent</name>
-  <version>9.14</version>
+  <version>9.15</version>
   <packaging>pom</packaging>
 
   <url>https://avaje-metrics.github.io</url>
@@ -23,7 +23,7 @@
 
   <properties>
     <nexus.staging.autoReleaseAfterClose>true</nexus.staging.autoReleaseAfterClose>
-    <project.build.outputTimestamp>2026-06-03T08:20:53Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-06-03T11:13:29Z</project.build.outputTimestamp>
   </properties>
 
   <modules>


### PR DESCRIPTION
This is better for open telemetry and prometheus reporting