### PR TITLE
bump opentelemetry to 1.63.0

### DIFF
--- a/metrics-otel-producer/pom.xml
+++ b/metrics-otel-producer/pom.xml
@@ -11,7 +11,7 @@
   <name>avaje-metrics-otel-producer</name>
 
   <properties>
-    <otel.version>1.62.0</otel.version>
+    <otel.version>1.63.0</otel.version>
     <surefire.useModulePath>false</surefire.useModulePath>
   </properties>
 

--- a/metrics-otel-reporter/pom.xml
+++ b/metrics-otel-reporter/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
-      <version>1.62.0</version>
+      <version>1.63.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/metrics-otel-trace/pom.xml
+++ b/metrics-otel-trace/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-api</artifactId>
-      <version>1.62.0</version>
+      <version>1.63.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/metrics-otel/pom.xml
+++ b/metrics-otel/pom.xml
@@ -11,7 +11,7 @@
   <name>avaje-metrics-otel</name>
 
   <properties>
-    <otel.version>1.62.0</otel.version>
+    <otel.version>1.63.0</otel.version>
     <surefire.useModulePath>false</surefire.useModulePath>
   </properties>
 


### PR DESCRIPTION
## Problem

`avaje-nima-opentelemetry` 1.10 (Helidon 4.5.0) pulls in `opentelemetry-instrumentation-api:2.29.0`, which references `io.opentelemetry.api.impl.InstrumentationUtil` — a class that only exists in `opentelemetry-api:1.63.0+`.

Without this bump, any project using both `avaje-metrics-otel` and `avaje-nima-opentelemetry:1.10` gets a `ClassNotFoundException: io.opentelemetry.api.impl.InstrumentationUtil` at runtime, because Maven's nearest-first dependency resolution picks `1.62.0` (declared directly by `avaje-metrics-otel`) over the `1.63.0` needed transitively.

## Fix

Bump `otel.version` from `1.62.0` → `1.63.0` in:
- `metrics-otel/pom.xml`
- `metrics-otel-producer/pom.xml`
- `metrics-otel-trace/pom.xml`
- `metrics-otel-reporter/pom.xml`