### PR TITLE
bump dependencies June 2026

### DIFF
--- a/metrics-ebean-insight/pom.xml
+++ b/metrics-ebean-insight/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>14.10.0</version>
+      <version>19.0.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/metrics-ebean/pom.xml
+++ b/metrics-ebean/pom.xml
@@ -32,21 +32,21 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>14.10.0</version>
+      <version>19.0.0</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-datasource-api</artifactId>
-      <version>10.0</version>
+      <version>10.9</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.6</version>
+      <version>1.8</version>
       <scope>test</scope>
     </dependency>
 

--- a/metrics-graphite/pom.xml
+++ b/metrics-graphite/pom.xml
@@ -32,14 +32,14 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>14.10.0</version>
+      <version>19.0.0</version>
       <optional>true</optional>
     </dependency>
 
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.6</version>
+      <version>1.8</version>
       <scope>test</scope>
     </dependency>
 

--- a/metrics-otel-reporter/pom.xml
+++ b/metrics-otel-reporter/pom.xml
@@ -45,14 +45,14 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk</artifactId>
-      <version>1.44.0</version>
+      <version>1.63.0</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-testing</artifactId>
-      <version>1.44.0</version>
+      <version>1.63.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/metrics-otel-trace/pom.xml
+++ b/metrics-otel-trace/pom.xml
@@ -39,14 +39,14 @@
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk</artifactId>
-      <version>1.44.0</version>
+      <version>1.63.0</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>io.opentelemetry</groupId>
       <artifactId>opentelemetry-sdk-testing</artifactId>
-      <version>1.44.0</version>
+      <version>1.63.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/metrics-prometheus/pom.xml
+++ b/metrics-prometheus/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.6</version>
+      <version>1.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/metrics-statsd/pom.xml
+++ b/metrics-statsd/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.datadoghq</groupId>
       <artifactId>java-dogstatsd-client</artifactId>
-      <version>4.4.4</version>
+      <version>4.4.5</version>
       <exclusions>
         <exclusion>
           <groupId>com.github.jnr</groupId>
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-datasource-api</artifactId>
-      <version>10.0</version>
+      <version>10.9</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>io.ebean</groupId>
       <artifactId>ebean-api</artifactId>
-      <version>17.0.0-RC2</version>
+      <version>19.0.0</version>
       <scope>provided</scope>
       <optional>true</optional>
     </dependency>
@@ -50,7 +50,7 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.6</version>
+      <version>1.8</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -30,21 +30,21 @@
     <dependency>
       <groupId>io.avaje</groupId>
       <artifactId>junit</artifactId>
-      <version>1.6</version>
+      <version>1.8</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.21.1</version>
+      <version>2.22.0</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.19.1</version>
+      <version>2.22.0</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Routine dependency updates across modules.

| Module | Dependency | From | To |
|---|---|---|---|
| metrics-ebean, metrics-ebean-insight, metrics-graphite | `ebean-api` (provided) | `14.10.0` | `19.0.0` |
| metrics-statsd | `ebean-api` (provided) | `17.0.0-RC2` | `19.0.0` |
| metrics-ebean, metrics-statsd | `ebean-datasource-api` | `10.0` | `10.9` |
| metrics-otel-trace, metrics-otel-reporter | `opentelemetry-sdk` (test) | `1.44.0` | `1.63.0` |
| metrics-statsd | `java-dogstatsd-client` | `4.4.4` | `4.4.5` |
| metrics | `jackson-core` / `jackson-databind` | `2.21.1` / `2.19.1` | `2.22.0` |
| metrics, metrics-ebean, metrics-graphite, metrics-statsd, metrics-prometheus | avaje `junit` | `1.6` | `1.8` |

Note: `ebean-api` is `provided` scope — no runtime impact on consumers, but aligns the compile-time API with current Ebean.